### PR TITLE
Bump NuGet dependencies and update FileAssert test names

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -57,13 +57,13 @@
       ]
     },
     "demaconsulting.reviewmark": {
-      "version": "1.2.0",
+      "version": "1.3.1",
       "commands": [
         "reviewmark"
       ]
     },
     "demaconsulting.fileassert": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "commands": [
         "fileassert"
       ]

--- a/docs/reqstream/ots/fileassert.yaml
+++ b/docs/reqstream/ots/fileassert.yaml
@@ -15,5 +15,5 @@ sections:
               proves the tool itself is operational before ReqStream consumes the results.
             tags: [ots]
             tests:
-              - FileAssert_Exists
-              - FileAssert_Contains
+              - FileAssert_File
+              - FileAssert_Text

--- a/src/DemaConsulting.SonarMark/DemaConsulting.SonarMark.csproj
+++ b/src/DemaConsulting.SonarMark/DemaConsulting.SonarMark.csproj
@@ -55,7 +55,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
-    <PackageReference Include="Polyfill" Version="10.10.0" PrivateAssets="All" />
+    <PackageReference Include="Polyfill" Version="10.11.1" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Code Analysis Dependencies -->

--- a/test/DemaConsulting.SonarMark.Tests/DemaConsulting.SonarMark.Tests.csproj
+++ b/test/DemaConsulting.SonarMark.Tests/DemaConsulting.SonarMark.Tests.csproj
@@ -33,7 +33,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>


### PR DESCRIPTION
This pull request mainly updates dependencies to their latest versions and adjusts test references for improved compatibility and reliability. It also updates test case names in a documentation file to reflect changes in the test suite.

**Dependency updates:**
* Updated `demaconsulting.reviewmark` to version `1.3.1` and `demaconsulting.fileassert` to version `0.5.1` in `.config/dotnet-tools.json`.
* Upgraded `Polyfill` package to version `10.11.1` in `DemaConsulting.SonarMark.csproj`.
* Bumped `Microsoft.NET.Test.Sdk` to version `18.7.0` in `DemaConsulting.SonarMark.Tests.csproj`.

**Documentation/test updates:**
* Renamed test cases in `fileassert.yaml` from `FileAssert_Exists`/`FileAssert_Contains` to `FileAssert_File`/`FileAssert_Text` to match the current test suite.