### PR TITLE
Add SysML2 architecture model support and update documentation

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -67,6 +67,12 @@
       "commands": [
         "fileassert"
       ]
+    },
+    "demaconsulting.sysml2tools.tool": {
+      "version": "0.1.0-beta.5",
+      "commands": [
+        "sysml2tools"
+      ]
     }
   }
 }

--- a/.cspell.yaml
+++ b/.cspell.yaml
@@ -75,6 +75,9 @@ words:
   - sonarscanner
   - spdx
   - spdxtool
+  - sysml
+  - sysml2tools
+  - SysML2Tools
   - testname
   - trx
   - vbproj

--- a/.github/agents/formal-review.agent.md
+++ b/.github/agents/formal-review.agent.md
@@ -31,12 +31,14 @@ standards from the selection matrix in AGENTS.md.
 1. Download the review checklist from
    <https://github.com/demaconsulting/ContinuousCompliance/raw/refs/heads/main/docs/review-template/review-template.md>.
    If the download fails, report the failure rather than proceeding without the template.
-2. Use `dotnet reviewmark --elaborate {review-set}` to get the files to review
-3. Review all files holistically, checking for cross-file consistency and
-   compliance with the review checklist
-4. Save the populated review checklist to `.agent-logs/reviews/review-report-{review-set}.md`.
+2. Run `dotnet reviewmark --elaborate {review-set}`. Read all files listed under
+   `## Context` first — these are reference material, not under review — then review
+   all files listed under `## Files` holistically, using the context to understand
+   the intended role and scope within the broader system, and checking for cross-file
+   consistency and compliance with the review checklist.
+3. Save the populated review checklist to `.agent-logs/reviews/review-report-{review-set}.md`.
    This directory holds formal review artifacts, not agent logs.
-5. Generate a completion report per the AGENTS.md reporting requirements.
+4. Generate a completion report per the AGENTS.md reporting requirements.
 
 # Report Template
 

--- a/.github/agents/template-sync.agent.md
+++ b/.github/agents/template-sync.agent.md
@@ -21,6 +21,8 @@ Delegate each group to a sub-agent.
 # Work Groups
 
 - **Root config files** - all non-collection files at the repository root
+- **`docs/sysml2/`** - SysML2 model files and rendered views (root-level flat folder,
+  not a Pandoc collection)
 - **One group per flat `docs/` folder** - e.g. `docs/build_notes/`, `docs/user_guide/`
 - **One group for root files in each of `docs/design/`, `docs/verification/`,
   `docs/reqstream/`** - e.g. `docs/design/introduction.md` — separate from the

--- a/.github/skills/sysml2tools-query/SKILL.md
+++ b/.github/skills/sysml2tools-query/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: sysml2tools-query
+description: Query this repository's SysML2 architecture model (docs/sysml2/) to understand software structure, purpose, and relationships before deep-diving into source code. Use this when asked to understand the codebase, find which unit implements something, assess the impact of a change, or trace requirements to code.
+---
+
+# SysML2Tools Query Skill
+
+This repository models its software structure in SysML2 under `docs/sysml2/`. Prefer
+querying this model over grepping/reading source files when you need to understand
+*what* a piece of the system is, *why* it exists, or *what it depends on*.
+
+## Prerequisites
+
+The `sysml2tools` CLI is a local .NET tool pinned in `.config/dotnet-tools.json`.
+Restore it once per session if not already available:
+
+```pwsh
+dotnet tool restore
+```
+
+## Model files
+
+- `docs/sysml2/model/{system-name}.sysml` — system-level `part def` only (no subsystems/units
+  inline). A repository may contain more than one system.
+- `docs/sysml2/model/{system-name}/{subsystem-name}.sysml` and
+  `docs/sysml2/model/{system-name}/{subsystem-name}/{unit-name}.sysml` — one file per
+  Subsystem/Unit, nested to mirror the same folder depth as that item's companion
+  `docs/design/`, `docs/reqstream/`, and `docs/verification/` files.
+- `docs/sysml2/model/ots.sysml` — off-the-shelf (OTS) dependency parts (present when OTS items
+  exist).
+- `docs/sysml2/model/shared.sysml` — Shared Package parts (present when Shared Package items
+  exist).
+- `docs/sysml2/views/design-views.sysml` — named views rendered for the design document; a
+  sibling of `model/`, not nested inside it. Not usually needed for query workflows, but
+  useful to see how diagrams are scoped.
+
+Always pass all `.sysml` files (or a glob covering them) to every `sysml2tools`
+invocation — the model spans multiple files and cross-references between them; files that
+reopen the same `package Name { ... }` from different files merge into one namespace
+automatically, no `import` required. As of `sysml2tools` 0.1.0-beta.5, every subcommand
+(`lint`, `render`, `query`) expands `*`/`**` glob patterns internally and recurses
+correctly — pass a single **quoted** glob string and let the tool resolve it, rather than
+relying on the shell (quoting works identically in both PowerShell and bash):
+
+```pwsh
+dotnet sysml2tools query list 'docs/sysml2/model/**/*.sysml'
+```
+
+## Artifact-location metadata
+
+Every System/Subsystem/Unit `part def` carries named `comment` elements pointing at its
+companion artifacts (source, test, design, verification, and — for repositories that still
+use ReqStream — requirements file). `query describe` returns every comment attached to
+an element, so one query gets you every artifact location for that item without grepping the
+source tree:
+
+```pwsh
+dotnet sysml2tools query describe -e {SystemName}::{UnitName} 'docs/sysml2/model/**/*.sysml'
+```
+
+```text
+- Documentation: One-line purpose statement for the unit.
+- Comment: Source: src/{Project}/{Subsystem}/{UnitName}.cs
+- Comment: Test: test/{Project}.Tests/{Subsystem}/{UnitName}Tests.cs
+- Comment: Design: docs/design/{system-name}/{subsystem-name}/{unit-name}.md
+- Comment: Verification: docs/verification/{system-name}/{subsystem-name}/{unit-name}.md
+- Comment: Requirements: docs/reqstream/{system-name}/{subsystem-name}/{unit-name}.yaml
+```
+
+Not every item has all five comments — Systems/Subsystems have no `Source` comment, and
+units without a dedicated companion doc point at their parent's doc instead (see the
+Artifact-Location Comments section of `sysml2-modeling.md` for the full rules). Prefer these
+paths over guessing a file location from the unit name; fall back to `grep`/`glob` only when
+a comment is missing or the model is stale.
+
+## Recommended workflow
+
+1. **Discover the system(s) present** — do not assume a fixed name:
+
+   ```pwsh
+   dotnet sysml2tools query list --kind "part def" 'docs/sysml2/model/**/*.sysml'
+   ```
+
+   Look for the top-level part def with no containing part (or the one with the most
+   children) to identify each system's qualified name.
+
+2. **Get the full hierarchy** (subsystems and units) for a system found above:
+
+   ```pwsh
+   dotnet sysml2tools query describe -e <QualifiedName> 'docs/sysml2/model/**/*.sysml'
+   ```
+
+   `describe` lists direct children and every artifact-location comment; repeat on each
+   child to walk deeper, or use `query list` to see the full flat inventory.
+
+3. **Understand a specific unit's purpose and find its files** before opening its source
+   file — `describe` returns both the purpose `doc` and every `Comment:` artifact-location
+   line in one call (see Artifact-location metadata above):
+
+   ```pwsh
+   dotnet sysml2tools query describe -e <QualifiedName> 'docs/sysml2/model/**/*.sysml'
+   ```
+
+4. **Assess impact before editing a unit** — see what depends on it:
+
+   ```pwsh
+   dotnet sysml2tools query used-by -e <QualifiedName> 'docs/sysml2/model/**/*.sysml'
+   dotnet sysml2tools query impact -e <QualifiedName> 'docs/sysml2/model/**/*.sysml'
+   ```
+
+   Note: this only surfaces structural (typing/containment) references modeled in
+   `.sysml` — not full call-graph/behavioral dependencies. Confirm actual usage in source
+   before making impact-sensitive changes.
+
+5. **Trace requirements** linked to a unit, if modeled:
+
+   ```pwsh
+   dotnet sysml2tools query requirements -e <QualifiedName> 'docs/sysml2/model/**/*.sysml'
+   ```
+
+6. **Search by name or kind** when the qualified name is unknown:
+
+   ```pwsh
+   dotnet sysml2tools query find --name <PartialOrFullName> 'docs/sysml2/model/**/*.sysml'
+   dotnet sysml2tools query list --kind "part def" 'docs/sysml2/model/**/*.sysml'
+   ```
+
+Use `--format json` on any query verb for machine-parsed output.
+
+## Fallback
+
+If the model is stale, doesn't yet cover a unit, or a query returns nothing useful, fall
+back to `grep`/`glob`/reading source directly. When you finish work that adds or changes a
+Unit/Subsystem, update the corresponding `.sysml` model file (including its artifact-location
+comments) in the same change (mirrors the existing requirement to keep `docs/design/*.md` and
+`docs/reqstream/*.yaml` companion artifacts in sync). See the `sysml2-modeling.md`
+standard for full modeling and view-authoring conventions.
+
+## Validating changes to the model
+
+Before committing changes to any `.sysml` file, lint it:
+
+```pwsh
+dotnet sysml2tools lint 'docs/sysml2/**/*.sysml'
+```

--- a/.github/standards/design-documentation.md
+++ b/.github/standards/design-documentation.md
@@ -8,6 +8,8 @@ globs: ["docs/design/**/*.md"]
 
 - **`technical-documentation.md`** - General technical documentation standards
 - **`software-items.md`** - Software categorization (System/Subsystem/Unit/OTS/Shared Package)
+- **`sysml2-modeling.md`** - SysML2 model and view conventions feeding the Software Structure
+  section
 
 # Folder Structure
 
@@ -30,7 +32,6 @@ docs/design/
 
 All sections in every file are mandatory; write "N/A - {justification}" rather than removing any.
 Determine subsystem vs. unit classification from `docs/design/introduction.md` — folder depth does not determine classification.
-Do not record version numbers anywhere in design documentation — version information is managed in SBOMs.
 
 # introduction.md (MANDATORY)
 
@@ -38,7 +39,8 @@ Must include:
 
 - **Purpose**: audience and compliance drivers
 - **Scope**: items covered and explicitly excluded (no test projects)
-- **Software Structure**: text tree showing all Systems/Subsystems/Units/OTS/Shared items
+- **Software Structure**: diagram(s) rendered from the SysML2 model under `docs/sysml2/`,
+  per `sysml2-modeling.md` — not a hand-maintained text tree
 - **Folder Layout**: text tree showing source folder structure
 - **Companion Artifact Structure**: parallel paths for requirements, design, verification, source, tests
 - **References** _(if applicable)_: external standards or specifications - only in `introduction.md`
@@ -98,6 +100,12 @@ For each Shared Package, create `docs/design/shared/{package-name}.md` (`##` hea
 - Use Mermaid diagrams to supplement (not replace) text
 - Use verbal cross-references ("see _Parser Design_") - not markdown hyperlinks (break in PDF)
 - Provide sufficient detail for formal code review
+- Do not record version numbers in design documentation — they go stale with dependency updates and
+  are managed in SBOMs. Version numbers are pinned release versions (e.g., `1.2.3`, `v2.0.1`).
+  The following are **not** version numbers and are permitted:
+  - Language/platform standards: `netstandard2.0`, `net10.0`, `C++20`, `C# 12` (stable standard identifiers)
+  - Protocol standards: `TLS 1.3`, `HTTP/2` (stable specifications)
+  - Placeholders: `0.0.0` (signals "not yet assigned")
 
 # Quality Checks
 

--- a/.github/standards/reviewmark-usage.md
+++ b/.github/standards/reviewmark-usage.md
@@ -21,70 +21,85 @@ review, organizes them into review-sets, and generates review plans and reports.
 - **Lint Configuration**: `dotnet reviewmark --lint`
 - **Elaborate Review-Set**: `dotnet reviewmark --elaborate {review-set}`
 - **Generate Plan**: `dotnet reviewmark --plan docs/code_review_plan/generated/plan.md --enforce`
-
-> **Note**: `--enforce` causes the plan to fail with a non-zero exit code if any repository
-> files are not covered by a review-set. Uncovered files indicate a gap in review-set
-> configuration that should be addressed.
+  (exits non-zero if any files are uncovered)
 
 ## Repository Structure
 
-Required repository items for ReviewMark operation:
-
 - `.reviewmark.yaml` - Configuration for review-sets, file-patterns, and review evidence-source.
-- `docs/code_review_plan/generated/` - Generated review plan (build output, do not edit)
-- `docs/code_review_report/generated/` - Generated review report (build output, do not edit)
 
 # Review Definition Structure
 
 Configure reviews in `.reviewmark.yaml` at repository root:
 
 ```yaml
-# Patterns identifying all files that require review
 needs-review:
-  # Include source code (adjust file extensions for your repo)
-  - "**/*.cs"           # C# source files
-  - "**/*.cpp"          # C++ source files
-  - "**/*.hpp"          # C++ header files
-  - "!**/bin/**"        # Generated source in build outputs
-  - "!**/obj/**"        # Generated source in build intermediates
+  - "**/*.cs"
+  - "**/*.cpp"
+  - "**/*.hpp"
+  - "!**/bin/**"
+  - "!**/obj/**"
+  - "requirements.yaml"
+  - "docs/reqstream/**/*.yaml"
+  - "docs/sysml2/**/*.sysml"
+  - "README.md"
+  - "docs/user_guide/**/*.md"
+  - "docs/design/**/*.md"
+  - "docs/verification/**/*.md"
 
-  # Include requirement files
-  - "requirements.yaml"        # Root requirements file
-  - "docs/reqstream/**/*.yaml" # Requirements files
-
-  # Include critical documentation files
-  - "README.md"                                 # Root level README
-  - "docs/user_guide/**/*.md"                   # User guide
-  - "docs/design/**/*.md"                       # Design documentation
-  - "docs/verification/**/*.md"                 # Verification design documentation
-
-# Source of review evidence
 evidence-source:
   type: none
 
-# Review-sets (each focuses on a single compliance question)
+context:
+  - docs/design/introduction.md
+
 reviews:
   - id: Purpose
-    title: Review of user-facing capabilities and system promises
+    title: Review that README and User Guide are Coherent and Complete
     paths:
       - "README.md"
       - "docs/user_guide/**/*.md"
-      - "docs/reqstream/{system-name}.yaml"
+  - id: Decomposition
+    title: Review that {SystemName} Decomposition Addresses the Stated Purpose
+    context:
+      - "README.md"
+      - "docs/user_guide/**/*.md"
+    paths:
+      - "requirements.yaml"
       - "docs/design/introduction.md"
-      - "docs/design/{system-name}.md"
 ```
 
-# Review-Set Design Principles
+For a complete annotated example with template directives, see `.reviewmark.yaml` in the
+reference template (`{template-url}/.reviewmark.yaml` per `AGENTS.md`).
 
-When constructing review-sets, follow these principles to maintain manageable scope and effective compliance evidence:
+# Review-Set Design Principles
 
 - **Hierarchical Scope**: Higher-level reviews exclude lower-level implementation details, relying instead on design
   documents to describe what components they use. System reviews exclude subsystem/unit details, subsystem reviews
   exclude unit source code, only unit reviews include actual implementation.
 - **Single Focus**: Each review-set proves one specific compliance question (user promises, system architecture,
   design consistency, etc.)
+- **Parent Context**: Unit and subsystem reviews include parent design and requirements as
+  context so reviewers understand the intended role and scope; see the Context Files section.
 - **Context Management**: Keep file counts manageable to prevent context overflow while maintaining complete coverage
   through the hierarchy
+
+# Context Files
+
+Context files are shown to reviewers for orientation but not fingerprinted. Add a top-level
+`context:` key for global context (every reviewer) and a per-review-set `context:` between
+`title:` and `paths:` for review-specific context. Always include `docs/design/introduction.md`
+as global context.
+
+| Review Type | Context to add |
+| :---------- | :------------- |
+| `Decomposition` | `README.md`, `docs/user_guide/**/*.md` |
+| `{SystemName}-Architecture` | `README.md`, `docs/user_guide/**/*.md` |
+| `{SystemName}-Design` | `docs/reqstream/{system-name}.yaml` |
+| `{SystemName}-Verification` | `docs/reqstream/{system-name}.yaml` |
+| `{SystemName}-AllRequirements` | Parent system design doc + `docs/reqstream/{system-name}.yaml` |
+| `{SystemName}-{UnitName}` (direct unit) | Parent system design doc + parent system requirements |
+| `{SystemName}-{SubsystemName}` (subsystem) | Parent system design doc + parent system requirements |
+| `{SystemName}-{SubsystemName}-{UnitName}` (unit under subsystem) | System + subsystem design docs + requirements |
 
 # Review-Set Organization
 
@@ -96,22 +111,29 @@ placeholders are always PascalCase (e.g., `{SystemName}`).
 
 ## `Purpose` Review (only one per repository)
 
-Reviews user-facing capabilities and system promises:
-
-- **Purpose**: Proves that the systems provide the capabilities the user is being told about
-- **Title**: "Review that Advertised Features Match System Design"
-- **Scope**: Excludes subsystem and unit files, relying on system-level design documents
-  to describe what subsystems and units they use
+- **Purpose**: Proves that the user-facing docs are coherent and complete — the north-star for the hierarchy
+- **Title**: "Review that README and User Guide are Coherent and Complete"
+- **ID**: `Purpose` (no system prefix — one per repository)
+- **Scope**: README and user_guide only; no requirements or design files
 - **File Path Patterns**:
   - README: `README.md`
   - User guide: `docs/user_guide/**/*.md`
-  - System requirements: `docs/reqstream/{system-name}.yaml`
+
+## `Decomposition` Review (only one per repository)
+
+- **Purpose**: Proves that the software items tree breakdown logically addresses the user-facing
+  promise; the structural mirror of the decomposition decision
+- **Title**: "Review that {SystemName} Decomposition Addresses the Stated Purpose"
+- **ID**: `Decomposition` (no system prefix — one per repository)
+- **Scope**: introduction.md (the decomposition narrative), the SysML2 model (the
+  authoritative structural tree), and requirements.yaml; no system-level detail
+- **File Path Patterns**:
+  - Root requirements: `requirements.yaml`
   - Design introduction: `docs/design/introduction.md`
-  - System design: `docs/design/{system-name}.md`
+  - SysML2 model: `docs/sysml2/**/*.sysml`
+- **Context Files**: `README.md`, `docs/user_guide/**/*.md`
 
 ## `{SystemName}-Architecture` Review (one per system)
-
-Reviews system architecture and operational validation:
 
 - **Purpose**: Proves that the system is designed and tested to satisfy its requirements
 - **Title**: "Review that {SystemName} Architecture Satisfies Requirements"
@@ -124,16 +146,15 @@ Reviews system architecture and operational validation:
   - Verification introduction: `docs/verification/introduction.md`
   - System verification design: `docs/verification/{system-name}.md`
   - System integration tests: `test/{SystemName}.Tests/{SystemName}Tests.{ext}`
+- **Context Files**: `README.md`, `docs/user_guide/**/*.md`
 
 ## `{SystemName}-Design` Review (one per system)
-
-Reviews architectural and design consistency:
 
 - **Purpose**: Proves the system design is consistent and complete
 - **Title**: "Review that {SystemName} Design is Consistent and Complete"
 - **Scope**: Only brings in top-level requirements and relies on brevity of design documentation
+- **Context Files**: `docs/reqstream/{system-name}.yaml`
 - **File Path Patterns**:
-  - System requirements: `docs/reqstream/{system-name}.yaml`
   - Platform requirements: `docs/reqstream/{system-name}/platform-requirements.yaml`
   - Design introduction: `docs/design/introduction.md`
   - System design: `docs/design/{system-name}.md`
@@ -143,13 +164,11 @@ Reviews architectural and design consistency:
 
 ## `{SystemName}-Verification` Review (one per system)
 
-Reviews verification completeness and consistency:
-
 - **Purpose**: Proves the system verification design is consistent and covers all requirements
 - **Title**: "Review that {SystemName} Verification is Consistent and Complete"
 - **Scope**: Only brings in top-level requirements and all verification docs for the system
+- **Context Files**: `docs/reqstream/{system-name}.yaml`
 - **File Path Patterns**:
-  - System requirements: `docs/reqstream/{system-name}.yaml`
   - Verification introduction: `docs/verification/introduction.md`
   - System verification: `docs/verification/{system-name}.md`
   - System verification files: `docs/verification/{system-name}/**/*.md`
@@ -158,19 +177,14 @@ Reviews verification completeness and consistency:
 
 ## `{SystemName}-AllRequirements` Review (one per system)
 
-Reviews requirements quality and traceability:
-
 - **Purpose**: Proves the requirements are consistent and complete
 - **Title**: "Review that All {SystemName} Requirements are Complete"
 - **Scope**: Only brings in requirements files to keep review manageable
 - **File Path Patterns**:
-  - Root requirements: `requirements.yaml`
-  - System requirements: `docs/reqstream/{system-name}.yaml`
   - Subsystem/unit requirements: `docs/reqstream/{system-name}/**/*.yaml`
+- **Context Files**: `docs/design/{system-name}.md`, `docs/reqstream/{system-name}.yaml`
 
 ## `{SystemName}-{SubsystemName}[-{SubsystemName}...]` Review (one per subsystem at any depth)
-
-Reviews subsystem architecture and interfaces:
 
 - **Purpose**: Proves that the subsystem is designed and tested to satisfy its requirements
 - **Title**: "Review that {SystemName} {SubsystemName} Satisfies Subsystem Requirements"
@@ -181,10 +195,9 @@ Reviews subsystem architecture and interfaces:
   - Design: `docs/design/{system-name}[/{subsystem-name}...]/{subsystem-name}.md`
   - Verification design: `docs/verification/{system-name}[/{subsystem-name}...]/{subsystem-name}.md`
   - Tests: `test/{SystemName}.Tests[/{SubsystemName}...]/{SubsystemName}Tests.{ext}`
+- **Context Files**: `docs/design/{system-name}.md`, `docs/reqstream/{system-name}.yaml`
 
 ## `{SystemName}-{SubsystemName}[-{SubsystemName}...]-{UnitName}` Review (one per unit)
-
-Reviews individual software unit implementation:
 
 - **Purpose**: Proves the unit is designed, implemented, and tested to satisfy its requirements
 - **Title**: "Review that {SystemName} {SubsystemName} {UnitName} Implementation is Correct"
@@ -197,10 +210,10 @@ Reviews individual software unit implementation:
   - Tests (C# example): `test/{SystemName}.Tests[/{SubsystemName}...]/{UnitName}Tests.cs`
   - Source (snake_case C++ example): `src/{system_name}[/{subsystem_name}...]/{unit_name}.cpp`
   - Tests (snake_case C++ example): `test/{system_name}_tests[/{subsystem_name}...]/{unit_name}_tests.cpp`
+- **Context Files**: Parent system design + requirements; add subsystem design +
+  requirements for each subsystem level above the unit.
 
 ## `OTS-{OtsName}` Review (one per OTS item)
-
-Reviews OTS item integration design, requirements, and verification evidence:
 
 - **Purpose**: Proves that the OTS item provides the required functionality and is correctly integrated
 - **Title**: "Review that {OtsName} Provides Required Functionality"
@@ -213,8 +226,6 @@ Reviews OTS item integration design, requirements, and verification evidence:
     (Python/other) — fixed repo-level name, no system prefix
 
 ## `Shared-{PackageName}` Review (one per Shared Package)
-
-Reviews Shared Package integration design, requirements, and verification evidence:
 
 - **Purpose**: Proves that the Shared Package provides the required advertised features and is correctly integrated
 - **Title**: "Review that {PackageName} Provides Required Features"
@@ -229,10 +240,9 @@ extensions (`.cs`, `.cpp`/`.hpp`, `.py`, etc.). Adapt to your repository's langu
 
 # Quality Checks
 
-Before submitting ReviewMark configuration, verify:
-
 - [ ] `.reviewmark.yaml` exists at repository root with proper structure
 - [ ] Review-set organization follows the standard hierarchy patterns
 - [ ] Each review-set focuses on a single compliance question (single focus principle)
 - [ ] File patterns use correct glob syntax and match intended files
 - [ ] Review-set file counts remain manageable (context management principle)
+- [ ] Context configured per the Context Files section

--- a/.github/standards/software-items.md
+++ b/.github/standards/software-items.md
@@ -130,3 +130,8 @@ the item is correct, well-designed, and proven to work:
 - **Verification Design** - HOW the requirements will be tested (applies to all item types)
 - **Source code** - The implementation of the design (local units only; not applicable to OTS or Shared Package)
 - **Tests** - PROOF the item does WHAT it is required to do (applies to all item types)
+
+Where the repository models its software structure in SysML2, each item's part def carries
+`comment` metadata pointing at these same artifact locations (`sourceRef`/`testRef`/
+`designRef`/`verificationRef`/`reqRef`) so agents can query them directly — see
+`sysml2-modeling.md`.

--- a/.github/standards/sysml2-modeling.md
+++ b/.github/standards/sysml2-modeling.md
@@ -1,0 +1,232 @@
+---
+name: SysML2 Modeling
+description: Follow these standards when creating or modifying the SysML2 architecture
+  model, its rendered views, or the software structure it feeds into design documentation.
+globs: ["docs/sysml2/**/*.sysml"]
+---
+
+# SysML2 Modeling Standard
+
+## Required Standards
+
+Read these standards first before applying this standard:
+
+- **`software-items.md`** - Software categorization (System/Subsystem/Unit/OTS/Shared Package)
+- **`design-documentation.md`** - Design document structure that embeds the diagrams this
+  standard produces
+
+## Purpose
+
+The repository's software structure is modeled in SysML2 under `docs/sysml2/` rather than
+hand-maintained as prose or an ASCII tree. The model is the authoritative, machine-queryable
+source of structure; rendered diagrams and `docs/design/introduction.md`'s narrative are
+generated/derived artifacts. AI agents should query the model (see `sysml2tools-query`
+skill) before deep-diving into source code to understand what a piece of the system is,
+why it exists, and what it depends on.
+
+## Repository Structure
+
+```text
+docs/sysml2/
+├── model/
+│   ├── {system-name}.sysml            # system-level part def only (no subsystems/units inline)
+│   ├── {system-name}/
+│   │   ├── {subsystem-name}.sysml     # subsystem part def; nests further for sub-subsystems
+│   │   └── {subsystem-name}/
+│   │       └── {unit-name}.sysml      # one file per unit
+│   ├── ots.sysml                      # OTS dependency parts (optional; if OTS items exist)
+│   └── shared.sysml                   # Shared Package parts (optional; if Shared Packages exist)
+└── views/
+    └── design-views.sysml             # named view usages rendered for the design document
+```
+
+`docs/sysml2/model/` mirrors the same folder shape as `docs/design/`, `docs/reqstream/`, and
+`docs/verification/` — one `.sysml` file per System/Subsystem/Unit, at the same nesting depth
+as that item's companion design/requirements/verification files. This keeps each file small
+and keeps PRs that touch one unit's model from producing unrelated diffs in unrelated units.
+`docs/sysml2/views/` is a sibling of `model/`, not nested inside it, so a single
+`docs/sysml2/model/**/*.sysml` glob never needs to exclude view files (`sysml2tools` has no
+exclude-glob syntax).
+
+There is no separate "stable entry point" file — a repository may contain multiple systems,
+so no single alias name would generalize. Agents discover the system(s) present by running
+`query list --kind "part def"` or `query find` (see the `sysml2tools-query` skill) over
+`docs/sysml2/model/**/*.sysml`, not by assuming a fixed name.
+
+Always pass the full set of `.sysml` files (or an equivalent glob) to every `sysml2tools`
+invocation — the model spans multiple files and cross-references between them; files sharing
+the same `package Name { ... }` merge into one namespace automatically with no `import`
+required, as long as all files are passed together. As of `sysml2tools` 0.1.0-beta.5,
+`lint` and `render` both expand `*`/`**` glob patterns internally (recursing correctly into
+subdirectories), so pass a single **quoted** glob string (e.g. `'docs/sysml2/**/*.sysml'`)
+and let the tool resolve it — do not rely on the shell to expand it, and do not quote-strip
+the pattern before it reaches the tool. Quoting keeps the behavior identical across
+PowerShell and bash, since neither shell needs to (or reliably does) expand `**` itself.
+
+## Model Content
+
+- `{system-name}.sysml` defines one `part def` for the System only, with `part` usages
+  referencing its direct Subsystems/Units (defined in their own files, see below).
+- Each `{subsystem-name}.sysml` / `{unit-name}.sysml` defines exactly one `part def`, with a
+  `doc /* ... */` comment stating its purpose — mirroring what would otherwise be written as
+  prose in `docs/design/introduction.md`'s Software Structure section. Subsystem files add
+  `part` usages for their own direct children (nested subsystems or units), matching the
+  Software Item Hierarchy in `software-items.md`.
+- `ots.sysml` / `shared.sysml` define one `part def` per OTS item / Shared Package, referenced
+  as `part` usages from the system(s) that depend on them.
+
+## Artifact-Location Comments
+
+Every System/Subsystem/Unit `part def` records where its companion artifacts live, as named
+`comment` elements — not `attribute`s (attribute values are not surfaced by `sysml2tools query
+describe`, even in JSON output; comments are). Comments have zero effect on rendered diagrams
+(verified: a part def with several comments attached renders with no extra nodes or size
+change) and are fully returned by `query describe`, in declaration order, as
+`Comment: ...` summary lines — this is how an agent gets every artifact location for a unit
+in a single query, without grepping the source tree.
+
+Use these comment names, in this order, when applicable to the item:
+
+```sysml
+part def {UnitName} {
+    doc /* One-line purpose statement. */
+
+    comment sourceRef /* Source: {path to the unit's source file} */
+    comment testRef /* Test: {path to the unit's test file} */
+    comment designRef /* Design: {path to the unit's design doc} */
+    comment verificationRef /* Verification: {path to the unit's verification doc} */
+    comment reqRef /* Requirements: {path to the unit's reqstream file} */
+}
+```
+
+Not every item has all five:
+
+- **Systems and Subsystems** have no `sourceRef` (no single source file represents a whole
+  system or subsystem) — use `testRef` for the subsystem-level test file when one exists.
+- **Units without a dedicated companion doc** (e.g. small data-model types documented inline
+  within their subsystem's design doc rather than in their own file) point `designRef` /
+  `verificationRef` / `reqRef` at the subsystem-level doc, with a short parenthetical note,
+  e.g. `/* Design: docs/design/{system}/{subsystem}.md (documented as a supporting value type) */`.
+- **Units without a dedicated test file** (exercised only indirectly through another unit's
+  tests) omit `testRef` entirely rather than pointing at an unrelated test file.
+- **OTS items** have no `sourceRef`/`testRef` (no local integration code); use `designRef`
+  (when the optional design doc exists) / `verificationRef` / `reqRef` only.
+
+This is prose-searchable metadata only — it is not a substitute for the authoritative
+requirements/design/verification artifacts, and it does not replace ReqStream as the
+requirements source of truth. (This repository currently keeps requirements traceability in
+ReqStream; a future migration to native SysML2 `requirement`/`satisfy` modeling is a separate,
+not-yet-scheduled change.)
+
+## Views (`docs/sysml2/views/design-views.sysml`)
+
+Views control what gets rendered into diagrams for the design document. Use named `view`
+**usages** (not `view def` **definitions**) — `expose` is only valid inside a usage:
+
+```sysml
+package {SystemName} {
+    view SoftwareStructureView {
+        expose {SystemName};         // whole package: system + subsystems + units
+    }
+
+    view {SystemName}View {
+        expose {SystemName}System;   // system def only, not expanded into subsystems
+    }
+
+    view {SubsystemName}View {
+        expose {SubsystemName};      // one subsystem def only
+    }
+}
+```
+
+**Critical distinction** (do not confuse these — this cost significant trial-and-error to
+discover): `expose <name>;` is what scopes a rendered diagram's content (the union of the
+named element's containment subtree). `render <kind>;` selects a rendering *style* (e.g.
+`asInterconnectionDiagram`) — it has **no effect on scope**. `expose` is only legal inside a named
+`view Name { ... }` **usage**; it is a syntax/semantic error inside a `view def Name { ... }`
+**definition**. `expose` targets must be `::`-qualified or locally-resolvable names, not
+dotted member-access chains (`expose foo.bar;` is invalid — use `expose Bar;`).
+
+**Naming convention** — one `View` suffix per rendered diagram, no `System`/`Subsystem`
+suffix duplication:
+
+- `SoftwareStructureView` - full detail: every system, subsystem, and unit in one diagram
+- `{SystemName}View` - one per system, direct members only (not expanded into subsystems)
+- `{SubsystemName}View` - one per subsystem (at any nesting depth), that subsystem's own
+  members only
+
+When a repository has multiple systems, `SoftwareStructureView` may expose each system's
+package individually (`expose {SystemNameA}; expose {SystemNameB};`) or the whole workspace,
+whichever produces a single coherent overview diagram.
+
+## Diagram Embedding
+
+Render with a single quoted recursive glob for the model tree, plus the views file
+(`sysml2tools` 0.1.0-beta.5+ expands and recurses `**` internally, so no shell-side globbing
+or explicit per-file listing is needed):
+
+```pwsh
+dotnet sysml2tools render `
+  --output docs/design/generated --format svg `
+  'docs/sysml2/model/**/*.sysml' `
+  'docs/sysml2/views/design-views.sysml'
+```
+
+With multiple views declared and no `--view` flag, `sysml2tools` renders every declared view
+in one invocation, one file per view, using each view's own name as the filename
+(`{ViewName}.svg`) — no post-render rename step is needed.
+
+Embed diagrams in `docs/design/` per this rule: every design doc for an item embeds the
+diagram for the narrowest view that still shows that item's own immediate structure —
+
+- `docs/design/introduction.md` — `SoftwareStructureView.svg` (the full-detail overview)
+- `docs/design/{system-name}.md` and every unit doc for a unit directly under the system
+  (no subsystem parent) — `{SystemName}View.svg`
+- `docs/design/{system-name}/{subsystem-name}.md` and every unit doc nested under that
+  subsystem (at any depth) — `{SubsystemName}View.svg`
+
+Place the image directly under the file's top-level heading, before its first prose
+subsection, e.g. `![{Name} Structure]({ViewName}.svg)`.
+
+## Build and Lint Integration
+
+- `sysml2tools lint` belongs in `lint.ps1`'s compliance-tools section, **not** as a separate
+  step in the CI design-document job — `lint.ps1` gates every later job (including document
+  generation) transitively, so linting the model there is both earlier and non-duplicated.
+  Pass a single quoted recursive glob, e.g. `dotnet sysml2tools lint 'docs/sysml2/**/*.sysml'`
+  — `sysml2tools` (0.1.0-beta.5+) expands and recurses this itself, so no
+  `Get-ChildItem`/shell-side globbing is needed.
+- The CI design-document job renders the views (see the render command above) before running
+  Pandoc, so generated SVGs exist before HTML generation. Rename/stable-filename workarounds
+  are unnecessary since view names are stable by definition. Pass the model and views globs as
+  separate quoted arguments (e.g. `'docs/sysml2/model/**/*.sysml' 'docs/sysml2/views/design-views.sysml'`)
+  — plain PowerShell (the default shell) is sufficient; no `shell: bash`/`shopt -s globstar`
+  workaround is needed.
+- Add `sysml2tools` to `.config/dotnet-tools.json` (`demaconsulting.sysml2tools.tool`) and to
+  `.versionmark.yaml`'s captured tool list.
+
+## Fallback
+
+If the model is stale, doesn't yet cover an item, or a query returns nothing useful, fall
+back to `grep`/`glob`/reading source directly. When work adds or changes a Unit/Subsystem,
+update the corresponding `.sysml` model file in the same change — this mirrors the existing
+requirement to keep `docs/design/*.md` and `docs/reqstream/*.yaml` companion artifacts in
+sync.
+
+## Quality Checks
+
+- [ ] Every System/Subsystem/Unit in `docs/design/introduction.md` has a matching `part def`
+  in its own file under `docs/sysml2/model/`, at the same folder depth as its companion
+  design/reqstream/verification files, with a purpose `doc` comment
+- [ ] Every Unit-level `part def` has `sourceRef`/`testRef`/`designRef`/`verificationRef`/
+  `reqRef` comments where applicable (see Artifact-Location Comments for documented
+  exceptions); System/Subsystem `part def`s have `testRef`/`designRef`/`verificationRef`/
+  `reqRef` but no `sourceRef`
+- [ ] `docs/sysml2/views/design-views.sysml` uses `view Name { expose ...; }` usages, not
+  `view def` definitions
+- [ ] View names follow the `SoftwareStructureView` / `{SystemName}View` /
+  `{SubsystemName}View` convention
+- [ ] `sysml2tools lint` passes on all `.sysml` files
+- [ ] Rendered diagrams are embedded in every design doc per the Diagram Embedding rule
+- [ ] `sysml2tools` is present in `lint.ps1`, `.config/dotnet-tools.json`, and
+  `.versionmark.yaml`

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -504,7 +504,7 @@ jobs:
           dotnet versionmark --capture --job-id "build-docs" \
             --output "artifacts/versionmark-build-docs.json" -- \
             dotnet git node npm pandoc weasyprint sarifmark sonarmark reqstream \
-            buildmark versionmark reviewmark fileassert
+            buildmark versionmark reviewmark fileassert sysml2tools
           echo "✓ Tool versions captured"
 
       # === PREPARE DOCUMENT OUTPUT ===
@@ -762,6 +762,20 @@ jobs:
       - name: Create design output directory
         shell: bash
         run: mkdir -p docs/design/generated
+
+      - name: Run SysML2Tools self-validation
+        run: >
+          dotnet sysml2tools
+          --validate
+          --results artifacts/sysml2tools-self-validation.trx
+
+      - name: Render Software Structure diagrams with SysML2Tools
+        shell: pwsh
+        run: >
+          dotnet sysml2tools render
+          --output docs/design/generated --format svg
+          'docs/sysml2/model/**/*.sysml'
+          'docs/sysml2/views/design-views.sysml'
 
       - name: Generate Design HTML with Pandoc
         shell: bash

--- a/.reviewmark.yaml
+++ b/.reviewmark.yaml
@@ -13,6 +13,7 @@ needs-review:
   - docs/reqstream/**/*.yaml  # Requirements files
   - docs/design/**/*.md  # Design documents
   - docs/verification/**/*.md  # Verification documents
+  - docs/sysml2/**/*.sysml  # SysML2 architecture model
   - '!**/obj/**'                 # Exclude build output
   - '!**/bin/**'                 # Exclude build output
   - '!**/generated/**'           # Exclude generated output
@@ -25,19 +26,38 @@ evidence-source:
   type: url
   location: https://raw.githubusercontent.com/demaconsulting/SonarMark/reviews/index.json
 
+# Global context shown to every reviewer for orientation (not fingerprinted).
+context:
+  - docs/design/introduction.md
+
 # Review sets following standardized patterns for hierarchical compliance coverage
 reviews:
   # Purpose Review (only one per repository)
   - id: Purpose
-    title: Review that Advertised Features Match System Design
+    title: Review that README and User Guide are Coherent and Complete
+    context:
+      - '!docs/design/introduction.md'                               # exclude design intro from user-facing review
     paths:
+      - README.md  # project readme
+      - docs/user_guide/**/*.md  # user guide
+
+  # Decomposition Review (only one per repository)
+  - id: Decomposition
+    title: Review that SonarMark Decomposition Addresses the Stated Purpose
+    context:
       - README.md
       - docs/user_guide/**/*.md
-      - docs/reqstream/sonar-mark/sonar-mark.yaml
-      - docs/design/introduction.md
-      - docs/design/sonar-mark.md
+    paths:
+      - requirements.yaml  # root requirements file
+      - docs/design/introduction.md  # design introduction
+      - docs/sysml2/**/*.sysml  # SysML2 model (authoritative structure)
+
+  # SonarMark-Architecture Review (one per system)
   - id: SonarMark-Architecture
     title: Review that SonarMark Architecture Satisfies Requirements
+    context:
+      - README.md
+      - docs/user_guide/**/*.md
     paths:
       - docs/reqstream/sonar-mark/sonar-mark.yaml
       - docs/design/introduction.md
@@ -51,8 +71,9 @@ reviews:
   # SonarMark-Design Review (one per system)
   - id: SonarMark-Design
     title: Review that SonarMark Design is Consistent and Complete
-    paths:
+    context:
       - docs/reqstream/sonar-mark/sonar-mark.yaml
+    paths:
       - docs/reqstream/sonar-mark/platform-requirements.yaml
       - docs/design/introduction.md
       - docs/design/sonar-mark.md
@@ -65,8 +86,9 @@ reviews:
   # SonarMark-Verification Review (one per system)
   - id: SonarMark-Verification
     title: Review that SonarMark Verification is Consistent and Complete
-    paths:
+    context:
       - docs/reqstream/sonar-mark/sonar-mark.yaml
+    paths:
       - docs/verification/introduction.md
       - docs/verification/sonar-mark.md
       - docs/verification/sonar-mark/**/*.md
@@ -78,21 +100,31 @@ reviews:
   # SonarMark-AllRequirements Review (one per system)
   - id: SonarMark-AllRequirements
     title: Review that All SonarMark Requirements are Complete
+    context:
+      - docs/design/sonar-mark.md
+      - docs/reqstream/sonar-mark/sonar-mark.yaml
     paths:
       - requirements.yaml
       - docs/reqstream/**/*.yaml
 
-  # Subsystem reviews -- subsystem req + design + subsystem test file only (NO unit source files)
+  # SonarMark-Cli Review (one per subsystem)
   - id: SonarMark-Cli
     title: Review that SonarMark Cli Satisfies Subsystem Requirements
+    context:
+      - docs/design/sonar-mark.md
+      - docs/reqstream/sonar-mark/sonar-mark.yaml
     paths:
       - docs/reqstream/sonar-mark/cli/cli.yaml
       - docs/design/sonar-mark/cli.md
       - docs/verification/sonar-mark/cli.md
       - test/**/Cli/CliTests.cs
 
+  # SonarMark-SonarIntegration Review (one per subsystem)
   - id: SonarMark-SonarIntegration
     title: Review that SonarMark SonarIntegration Satisfies Subsystem Requirements
+    context:
+      - docs/design/sonar-mark.md
+      - docs/reqstream/sonar-mark/sonar-mark.yaml
     paths:
       - docs/reqstream/sonar-mark/sonar-integration/sonar-integration.yaml
       - docs/design/sonar-mark/sonar-integration.md
@@ -100,89 +132,153 @@ reviews:
       - test/**/SonarIntegration/SonarIntegrationTests.cs
       - test/**/SonarIntegration/SonarIntegrationTestHelpers.cs
 
+  # SonarMark-ReportGeneration Review (one per subsystem)
   - id: SonarMark-ReportGeneration
     title: Review that SonarMark ReportGeneration Satisfies Subsystem Requirements
+    context:
+      - docs/design/sonar-mark.md
+      - docs/reqstream/sonar-mark/sonar-mark.yaml
     paths:
       - docs/reqstream/sonar-mark/report-generation/report-generation.yaml
       - docs/design/sonar-mark/report-generation.md
       - docs/verification/sonar-mark/report-generation.md
       - test/**/ReportGeneration/ReportGenerationTests.cs
 
+  # SonarMark-SelfTest Review (one per subsystem)
   - id: SonarMark-SelfTest
     title: Review that SonarMark SelfTest Satisfies Subsystem Requirements
+    context:
+      - docs/design/sonar-mark.md
+      - docs/reqstream/sonar-mark/sonar-mark.yaml
     paths:
       - docs/reqstream/sonar-mark/self-test/self-test.yaml
       - docs/design/sonar-mark/self-test.md
       - docs/verification/sonar-mark/self-test.md
       - test/**/SelfTest/SelfTestTests.cs
 
-  # Unit reviews -- include actual source code + unit tests
-  - id: SonarMark-Cli-Context
-    title: Review that SonarMark Cli Context Implementation is Correct
-    paths:
-      - docs/reqstream/sonar-mark/cli/context.yaml
-      - docs/design/sonar-mark/cli/context.md
-      - src/**/Context.cs
-      - test/**/ContextTests.cs
-
+  # SonarMark-Program Review (one per unit; direct unit under the system)
   - id: SonarMark-Program
     title: Review that SonarMark Program Implementation is Correct
+    context:
+      - docs/design/sonar-mark.md
+      - docs/reqstream/sonar-mark/sonar-mark.yaml
     paths:
       - docs/reqstream/sonar-mark/program.yaml
       - docs/design/sonar-mark/program.md
+      - docs/verification/sonar-mark/program.md
       - src/**/Program.cs
       - test/**/ProgramTests.cs
 
-  - id: SonarMark-SelfTest-Validation
-    title: Review that SonarMark SelfTest Validation Implementation is Correct
+  # SonarMark-Cli-Context Review (one per unit)
+  - id: SonarMark-Cli-Context
+    title: Review that SonarMark Cli Context Implementation is Correct
+    context:
+      - docs/design/sonar-mark.md
+      - docs/reqstream/sonar-mark/sonar-mark.yaml
+      - docs/design/sonar-mark/cli.md
+      - docs/reqstream/sonar-mark/cli/cli.yaml
     paths:
-      - docs/reqstream/sonar-mark/self-test/validation.yaml
-      - docs/design/sonar-mark/self-test/validation.md
-      - src/**/Validation.cs
-      - test/**/ValidationTests.cs
+      - docs/reqstream/sonar-mark/cli/context.yaml
+      - docs/design/sonar-mark/cli/context.md
+      - docs/verification/sonar-mark/cli/context.md
+      - src/**/Cli/Context.cs
+      - test/**/Cli/ContextTests.cs
 
-  - id: SonarMark-SonarIntegration-SonarHotSpot
-    title: Review that SonarMark SonarIntegration SonarHotSpot Implementation is Correct
-    paths:
-      - docs/reqstream/sonar-mark/sonar-integration/sonar-hot-spot.yaml
-      - docs/design/sonar-mark/sonar-integration/sonar-hot-spot.md
-      - src/**/SonarHotSpot.cs
-      - test/**/SonarHotSpotTests.cs
-
-  - id: SonarMark-SonarIntegration-SonarIssue
-    title: Review that SonarMark SonarIntegration SonarIssue Implementation is Correct
-    paths:
-      - docs/reqstream/sonar-mark/sonar-integration/sonar-issue.yaml
-      - docs/design/sonar-mark/sonar-integration/sonar-issue.md
-      - src/**/SonarIssue.cs
-      - test/**/SonarIssueTests.cs
-
-  - id: SonarMark-ReportGeneration-SonarQualityResult
-    title: Review that SonarMark ReportGeneration SonarQualityResult Implementation is Correct
-    paths:
-      - docs/reqstream/sonar-mark/report-generation/sonar-quality-result.yaml
-      - docs/design/sonar-mark/report-generation/sonar-quality-result.md
-      - src/**/SonarQualityResult.cs
-      - test/**/SonarQualityResultTests.cs
-
+  # SonarMark-SonarIntegration-SonarQubeClient Review (one per unit)
   - id: SonarMark-SonarIntegration-SonarQubeClient
     title: Review that SonarMark SonarIntegration SonarQubeClient Implementation is Correct
+    context:
+      - docs/design/sonar-mark.md
+      - docs/reqstream/sonar-mark/sonar-mark.yaml
+      - docs/design/sonar-mark/sonar-integration.md
+      - docs/reqstream/sonar-mark/sonar-integration/sonar-integration.yaml
     paths:
       - docs/reqstream/sonar-mark/sonar-integration/sonar-qube-client.yaml
       - docs/design/sonar-mark/sonar-integration/sonar-qube-client.md
-      - src/**/SonarQubeClient.cs
-      - test/**/SonarQubeClientTests.cs
+      - docs/verification/sonar-mark/sonar-integration/sonar-qube-client.md
+      - src/**/SonarIntegration/SonarQubeClient.cs
+      - test/**/SonarIntegration/SonarQubeClientTests.cs
 
-  # Shared Package reviews -- shared req + design + verification only (no local source)
-  - id: SonarMark-Shared
-    title: Review of SonarMark Shared Package Section
+  # SonarMark-SonarIntegration-SonarHotSpot Review (one per unit)
+  - id: SonarMark-SonarIntegration-SonarHotSpot
+    title: Review that SonarMark SonarIntegration SonarHotSpot Implementation is Correct
+    context:
+      - docs/design/sonar-mark.md
+      - docs/reqstream/sonar-mark/sonar-mark.yaml
+      - docs/design/sonar-mark/sonar-integration.md
+      - docs/reqstream/sonar-mark/sonar-integration/sonar-integration.yaml
     paths:
-      - docs/design/shared.md
-      - docs/verification/shared.md
+      - docs/reqstream/sonar-mark/sonar-integration/sonar-hot-spot.yaml
+      - docs/design/sonar-mark/sonar-integration/sonar-hot-spot.md
+      - docs/verification/sonar-mark/sonar-integration/sonar-hot-spot.md
+      - src/**/SonarIntegration/SonarHotSpot.cs
+      - test/**/SonarIntegration/SonarHotSpotTests.cs
 
-  - id: SonarMark-Shared-SonarMark
+  # SonarMark-SonarIntegration-SonarIssue Review (one per unit)
+  - id: SonarMark-SonarIntegration-SonarIssue
+    title: Review that SonarMark SonarIntegration SonarIssue Implementation is Correct
+    context:
+      - docs/design/sonar-mark.md
+      - docs/reqstream/sonar-mark/sonar-mark.yaml
+      - docs/design/sonar-mark/sonar-integration.md
+      - docs/reqstream/sonar-mark/sonar-integration/sonar-integration.yaml
+    paths:
+      - docs/reqstream/sonar-mark/sonar-integration/sonar-issue.yaml
+      - docs/design/sonar-mark/sonar-integration/sonar-issue.md
+      - docs/verification/sonar-mark/sonar-integration/sonar-issue.md
+      - src/**/SonarIntegration/SonarIssue.cs
+      - test/**/SonarIntegration/SonarIssueTests.cs
+
+  # SonarMark-ReportGeneration-SonarQualityResult Review (one per unit)
+  - id: SonarMark-ReportGeneration-SonarQualityResult
+    title: Review that SonarMark ReportGeneration SonarQualityResult Implementation is Correct
+    context:
+      - docs/design/sonar-mark.md
+      - docs/reqstream/sonar-mark/sonar-mark.yaml
+      - docs/design/sonar-mark/report-generation.md
+      - docs/reqstream/sonar-mark/report-generation/report-generation.yaml
+    paths:
+      - docs/reqstream/sonar-mark/report-generation/sonar-quality-result.yaml
+      - docs/design/sonar-mark/report-generation/sonar-quality-result.md
+      - docs/verification/sonar-mark/report-generation/sonar-quality-result.md
+      - src/**/ReportGeneration/SonarQualityResult.cs
+      - test/**/ReportGeneration/SonarQualityResultTests.cs
+
+  # SonarMark-SelfTest-Validation Review (one per unit)
+  - id: SonarMark-SelfTest-Validation
+    title: Review that SonarMark SelfTest Validation Implementation is Correct
+    context:
+      - docs/design/sonar-mark.md
+      - docs/reqstream/sonar-mark/sonar-mark.yaml
+      - docs/design/sonar-mark/self-test.md
+      - docs/reqstream/sonar-mark/self-test/self-test.yaml
+    paths:
+      - docs/reqstream/sonar-mark/self-test/validation.yaml
+      - docs/design/sonar-mark/self-test/validation.md
+      - docs/verification/sonar-mark/self-test/validation.md
+      - src/**/SelfTest/Validation.cs
+      - test/**/SelfTest/ValidationTests.cs
+
+  # OTS-TestResults Review (one per OTS item)
+  - id: OTS-TestResults
+    title: Review that TestResults Provides Required Functionality
+    paths:
+      - docs/reqstream/ots/test-results.yaml  # OTS requirements
+      - docs/design/ots/test-results.md  # OTS design
+      - docs/verification/ots/test-results.md  # OTS verification
+
+  # OTS-SysML2Tools Review (one per OTS item)
+  - id: OTS-SysML2Tools
+    title: Review that SysML2Tools Provides Required Functionality
+    paths:
+      - docs/reqstream/ots/sysml2tools.yaml  # OTS requirements
+      - docs/design/ots/sysml2tools.md  # OTS design
+      - docs/verification/ots/sysml2tools.md  # OTS verification
+
+  # Shared-SonarMark Review (one per Shared Package)
+  - id: Shared-SonarMark
     title: Review that SonarMark Provides Required Features
     paths:
-      - docs/reqstream/shared/sonar-mark.yaml
-      - docs/design/shared/sonar-mark.md
-      - docs/verification/shared/sonar-mark.md
+      - docs/reqstream/shared/sonar-mark.yaml  # Shared Package requirements
+      - docs/design/shared/sonar-mark.md  # Shared Package design
+      - docs/verification/shared/sonar-mark.md  # Shared Package verification

--- a/.versionmark.yaml
+++ b/.versionmark.yaml
@@ -73,3 +73,8 @@ tools:
   fileassert:
     command: dotnet tool list
     regex: '(?i)demaconsulting\.fileassert\s+(?<version>\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?)'
+
+  # sysml2tools (DemaConsulting.Sysml2Tools.Tool from dotnet tool list)
+  sysml2tools:
+    command: dotnet tool list
+    regex: '(?i)demaconsulting\.sysml2tools\.tool\s+(?<version>\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?)'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@
 │   ├── requirements_doc/
 │   ├── requirements_report/
 │   ├── reqstream/
+│   ├── sysml2/
 │   ├── user_guide/
 │   └── verification/
 ├── src/
@@ -45,10 +46,12 @@ This repository follows a reference template for structure and file conventions.
 
 # Codebase Navigation (ALL Agents)
 
-When working with source code, design, or requirements artifacts, read
-`docs/design/introduction.md` first. It provides the software structure,
-folder layout, and companion artifact locations. Use it as the primary map
-before searching the filesystem.
+When working with source code, design, or requirements artifacts, query the SysML2
+architecture model under `docs/sysml2/` first (see the `sysml2tools-query` skill) to
+understand software structure, purpose, and relationships. Fall back to
+`docs/design/introduction.md` for the human-facing narrative, folder layout, and
+companion artifact locations, and use it as the primary map when the model doesn't
+yet cover something.
 
 # Key Configuration Files
 
@@ -63,6 +66,7 @@ before searching the filesystem.
 - **`package.json`** - Node.js dependencies for formatting tools
 - **`requirements.yaml`** - Root requirements file with includes
 - **`pip-requirements.txt`** - Python dependencies for yamllint and yamlfix
+- **`docs/sysml2/`** - SysML2 architecture model; authoritative source for software structure
 - **`fix.ps1`** - Applies all auto-fixers silently (dotnet format, markdown, YAML). Always exits 0.
 - **`build.ps1`** - Builds the solution and runs all tests.
 
@@ -79,6 +83,7 @@ from `.github/standards/`. Use this matrix to determine which to load:
 - **Design docs**: `software-items.md`, `design-documentation.md`, `technical-documentation.md`
 - **Verification docs**: `software-items.md`, `verification-documentation.md`, `technical-documentation.md`
 - **Review configuration**: `software-items.md`, `reviewmark-usage.md`
+- **Software structure**: `sysml2-modeling.md`
 - **Any documentation**: `technical-documentation.md`
 
 Load only the standards relevant to your specific task scope.
@@ -133,7 +138,7 @@ responsibility - invoke the lint-fix agent once before submitting a pull request
 ## CI Quality Tools
 
 CI runs `lint.ps1` which checks: markdownlint-cli2, cspell, yamllint, dotnet format,
-reqstream, versionmark, and reviewmark.
+reqstream, versionmark, reviewmark, and sysml2tools.
 
 # Scope Discipline (ALL Agents Must Follow)
 

--- a/docs/design/definition.yaml
+++ b/docs/design/definition.yaml
@@ -27,6 +27,7 @@ input-files:
   - docs/design/sonar-mark/self-test/validation.md
   - docs/design/ots.md
   - docs/design/ots/test-results.md
+  - docs/design/ots/sysml2tools.md
   - docs/design/shared.md
   - docs/design/shared/sonar-mark.md
 template: template.html

--- a/docs/design/introduction.md
+++ b/docs/design/introduction.md
@@ -19,6 +19,7 @@ Local items:
 OTS items:
 
 - **DemaConsulting.TestResults**: integration and usage design.
+- **SysML2Tools**: integration and usage design.
 
 Shared Packages:
 
@@ -28,27 +29,12 @@ Out of scope: test projects, build pipeline scripts, and CI configuration.
 
 ## Software Structure
 
-- **SonarMark** (System) - .NET CLI tool for generating markdown reports from SonarQube/SonarCloud analysis results
-  - **Program** (Unit) - entry point, dispatch, parameter validation, and report writing
-  - **Cli** (Subsystem) - command-line interface and argument parsing
-    - **Context** (Unit) - argument parsing, output, log-file, enforce, and results-file handling
-  - **SonarIntegration** (Subsystem) - SonarQube/SonarCloud API integration
-    - **SonarQubeClient** (Unit) - HTTP API client, fetches quality gate, issues, and hot-spots
-    - **SonarHotSpot** (Unit) - data record representing a SonarQube security hot-spot
-    - **SonarIssue** (Unit) - data record representing a SonarQube issue
-  - **ReportGeneration** (Subsystem) - markdown report generation
-    - **SonarQualityResult** (Unit) - aggregates results and renders the markdown report
-  - **SelfTest** (Subsystem) - self-validation runner
-    - **Validation** (Unit) - self-validation runner, writes TRX and JUnit result files
+The software structure is modeled in SysML2 under `docs/sysml2/` and rendered to the
+diagram below by SysML2Tools as part of the build pipeline. AI agents should query the
+SysML2 model directly (see the `sysml2tools-query` skill) rather than parsing this
+diagram or the prose below.
 
-**OTS Dependencies:**
-
-- **DemaConsulting.TestResults** (OTS) - test result collection and serialization (TRX/JUnit XML)
-
-**Shared Package Dependencies:**
-
-- **SonarMark** (Shared Package) - released SonarMark tool used in `build-docs` for self-validation
-  and SonarCloud quality report generation
+![Software Structure](SoftwareStructureView.svg)
 
 ## Folder Layout
 

--- a/docs/design/ots/sysml2tools.md
+++ b/docs/design/ots/sysml2tools.md
@@ -1,0 +1,52 @@
+## SysML2Tools OTS Design
+
+DemaConsulting.SysML2Tools is a .NET dotnet global tool that lints a SysML2 architecture model
+and renders its declared views to SVG diagrams consumed by the design documentation.
+
+### Purpose
+
+SysML2Tools provides the toolchain that keeps SonarMark's architecture model
+(`docs/sysml2/model/**/*.sysml`) and its declared views (`docs/sysml2/views/design-views.sysml`)
+consistent with the design documentation. It validates the model for syntax and reference errors,
+and renders each declared view to an SVG diagram embedded directly in the corresponding design
+document (for example `docs/design/introduction.md` embeds `SoftwareStructureView.svg`). AI agents
+also query the model directly via the `sysml2tools-query` skill rather than parsing the rendered
+diagrams or hand-maintained prose.
+
+SysML2Tools is chosen because it is the reference implementation for the SysML v2 subset used by
+this project's Continuous Compliance methodology, and it integrates directly with the same
+dotnet-tool restore and CI pipeline used by the other pipeline tools.
+
+### Features Used
+
+- Model validation via `dotnet sysml2tools lint 'docs/sysml2/**/*.sysml'`, which reports syntax
+  errors and unresolved references without producing output files.
+- View rendering via
+  `dotnet sysml2tools render --output docs/design/generated --format svg 'docs/sysml2/model/**/*.sysml' 'docs/sysml2/views/design-views.sysml'`,
+  which renders every `view` declared in `design-views.sysml` to an SVG file named after the view
+  (for example `SoftwareStructureView.svg`).
+- Model querying via the `sysml2tools-query` skill, used by AI agents to answer structural and
+  traceability questions about the model without parsing the raw SysML2 source or the rendered
+  diagrams.
+
+### Integration Pattern
+
+SysML2Tools is installed as a .NET local tool defined in `.config/dotnet-tools.json` under the
+package name `demaconsulting.sysml2tools.tool` and restored with `dotnet tool restore`. It operates
+directly on the SysML2 source files under `docs/sysml2/`; no separate configuration file is
+required.
+
+It is used in two places in the pipeline:
+
+- **Lint** (`lint.ps1`, all CI jobs and local pre-PR checks): `dotnet sysml2tools lint
+  'docs/sysml2/**/*.sysml'` fails the build if the model contains syntax errors or unresolved
+  references.
+- **Render** (`build.yaml`, build-docs job): `dotnet sysml2tools render` renders each declared view
+  to an SVG file in `docs/design/generated/`, immediately before Pandoc compiles the Design
+  document. The rendered SVGs sit alongside the compiled `design.html`, so the design Markdown
+  sources embed bare filenames (for example `![Software Structure](SoftwareStructureView.svg)`)
+  that Pandoc and the browser resolve relative to that directory.
+
+SysML2Tools reads only the local SysML2 model files and writes only local SVG output files; it
+requires no external service or network access, and it has no transitive NuGet dependencies that
+propagate to the main source project. It is a build-time tool only.

--- a/docs/design/shared/sonar-mark.md
+++ b/docs/design/shared/sonar-mark.md
@@ -20,7 +20,7 @@ a prior released version of the same tool consumed as a dependency by its own bu
 Per the software-items standard, a software package produced within the same program and
 consumed as a dependency is classified as a Shared Package.
 
-### Features Used
+### Advertised Features Consumed
 
 - **Self-Validation (`--validate`)** — runs SonarMark's four built-in self-validation
   scenarios (quality gate retrieval, issues retrieval, hot-spots retrieval, and markdown
@@ -38,3 +38,22 @@ The released SonarMark is listed as `demaconsulting.sonarmark` in
 `.config/dotnet-tools.json` and is installed with `dotnet tool restore`. No additional
 initialization or configuration is required; both features are invoked directly from
 `build-docs` CI job steps using the `dotnet sonarmark` command.
+
+### Assumptions
+
+The `build-docs` job makes the following assumptions about the released SonarMark binary
+pinned in `.config/dotnet-tools.json`:
+
+- **Stable CLI contract** — the `--validate`, `--server`, `--project-key`, and `--report`
+  flags, and their accepted argument formats, remain stable for the pinned version; no
+  flag renames or removed options occur without a corresponding update to the pinned version.
+- **Stable exit-code contract** — the released binary returns a zero exit code on success and
+  a non-zero exit code on failure (self-validation failure or report-generation failure), so
+  the `build-docs` job can detect failures reliably.
+- **Well-formed markdown output** — the `--report` output is valid, well-formed Markdown that
+  can be embedded in `docs/code_quality/generated/sonar-quality.md` without further
+  post-processing or repair.
+- **Deterministic self-validation** — the four `--validate` scenarios (quality gate retrieval,
+  issues retrieval, hot-spots retrieval, and markdown report generation) exercise the same
+  SonarQube/SonarCloud REST API surface used by report generation, so a passing
+  self-validation is a reliable predictor that report generation will also succeed.

--- a/docs/design/sonar-mark.md
+++ b/docs/design/sonar-mark.md
@@ -1,5 +1,7 @@
 # SonarMark
 
+![SonarMark Structure](SonarMarkView.svg)
+
 ## Architecture
 
 SonarMark operates as a single-process .NET CLI tool. The four subsystems collaborate in

--- a/docs/design/sonar-mark/cli.md
+++ b/docs/design/sonar-mark/cli.md
@@ -1,5 +1,7 @@
 ## Cli
 
+![Cli Structure](CliView.svg)
+
 ### Overview
 
 The Cli subsystem handles command-line argument parsing and program output routing for the

--- a/docs/design/sonar-mark/cli/context.md
+++ b/docs/design/sonar-mark/cli/context.md
@@ -1,5 +1,7 @@
 ### Context
 
+![Cli Structure](CliView.svg)
+
 #### Purpose
 
 `Context` parses command-line arguments, manages console output (including silent mode and

--- a/docs/design/sonar-mark/program.md
+++ b/docs/design/sonar-mark/program.md
@@ -1,5 +1,7 @@
 ## Program
 
+![SonarMark Structure](SonarMarkView.svg)
+
 ### Purpose
 
 `Program` is the static entry point for the SonarMark application. It contains `Main`, which

--- a/docs/design/sonar-mark/report-generation.md
+++ b/docs/design/sonar-mark/report-generation.md
@@ -1,5 +1,7 @@
 ## ReportGeneration
 
+![ReportGeneration Structure](ReportGenerationView.svg)
+
 ### Overview
 
 The ReportGeneration subsystem aggregates the quality analysis results returned by the

--- a/docs/design/sonar-mark/report-generation/sonar-quality-result.md
+++ b/docs/design/sonar-mark/report-generation/sonar-quality-result.md
@@ -1,5 +1,7 @@
 ### SonarQualityResult
 
+![ReportGeneration Structure](ReportGenerationView.svg)
+
 #### Purpose
 
 `SonarQualityResult` is an immutable record that aggregates the full quality analysis result

--- a/docs/design/sonar-mark/self-test.md
+++ b/docs/design/sonar-mark/self-test.md
@@ -1,5 +1,7 @@
 ## SelfTest
 
+![SelfTest Structure](SelfTestView.svg)
+
 ### Overview
 
 The SelfTest subsystem provides a built-in self-validation mode that verifies the tool's

--- a/docs/design/sonar-mark/self-test/validation.md
+++ b/docs/design/sonar-mark/self-test/validation.md
@@ -1,5 +1,7 @@
 ### Validation
 
+![SelfTest Structure](SelfTestView.svg)
+
 #### Purpose
 
 `Validation` provides the self-validation capability of SonarMark. When the tool is invoked

--- a/docs/design/sonar-mark/sonar-integration.md
+++ b/docs/design/sonar-mark/sonar-integration.md
@@ -1,5 +1,7 @@
 ## SonarIntegration
 
+![SonarIntegration Structure](SonarIntegrationView.svg)
+
 ### Overview
 
 The SonarIntegration subsystem is responsible for communicating with SonarQube/SonarCloud

--- a/docs/design/sonar-mark/sonar-integration/sonar-hot-spot.md
+++ b/docs/design/sonar-mark/sonar-integration/sonar-hot-spot.md
@@ -1,5 +1,7 @@
 ### SonarHotSpot
 
+![SonarIntegration Structure](SonarIntegrationView.svg)
+
 #### Purpose
 
 `SonarHotSpot` is an immutable positional record that represents a single security hot-spot

--- a/docs/design/sonar-mark/sonar-integration/sonar-issue.md
+++ b/docs/design/sonar-mark/sonar-integration/sonar-issue.md
@@ -1,5 +1,7 @@
 ### SonarIssue
 
+![SonarIntegration Structure](SonarIntegrationView.svg)
+
 #### Purpose
 
 `SonarIssue` is an immutable positional record that represents a single code quality issue

--- a/docs/design/sonar-mark/sonar-integration/sonar-qube-client.md
+++ b/docs/design/sonar-mark/sonar-integration/sonar-qube-client.md
@@ -1,5 +1,7 @@
 ### SonarQubeClient
 
+![SonarIntegration Structure](SonarIntegrationView.svg)
+
 #### Purpose
 
 `SonarQubeClient` is the HTTP client responsible for communicating with the
@@ -28,7 +30,7 @@ while any async operation is outstanding.
   name; `CancellationToken cancellationToken` — optional cancellation.
 - *Returns*: `Task<SonarQualityResult>` — assembled quality result.
 - *Preconditions*: `serverUrl` and `projectKey` must not be null or whitespace; throws
-  `ArgumentException` otherwise.
+  `ArgumentNullException` for null, `ArgumentException` for empty or whitespace.
 - *Postconditions*: Returns a fully populated `SonarQualityResult` on success.
 
 Calls `GetProjectNameByKeyAsync`, `GetQualityGateStatusByBranchAsync`,

--- a/docs/reqstream/ots/sysml2tools.yaml
+++ b/docs/reqstream/ots/sysml2tools.yaml
@@ -1,0 +1,38 @@
+---
+# SysML2Tools OTS Software Requirements
+#
+# Requirements for the SysML2Tools architecture modeling tool functionality.
+
+sections:
+  - title: OTS Software Requirements
+    sections:
+      - title: SysML2Tools Requirements
+        requirements:
+          - id: SonarMark-OTS-SysML2Tools-Lint
+            title: SysML2Tools shall validate the SysML2 model for syntax and reference errors.
+            justification: |
+              Linting the model in CI catches broken references and syntax errors in the
+              architecture model before they reach the generated documentation.
+            tags: [ots]
+            tests:
+              - SysML2Tools_LintSelfTest
+
+          - id: SonarMark-OTS-SysML2Tools-Render
+            title: SysML2Tools shall render the declared views to SVG diagrams.
+            justification: |
+              The rendered diagrams are embedded in the design documentation, so a failure to
+              render must fail the build rather than silently omit a diagram.
+            tags: [ots]
+            tests:
+              - SysML2Tools_RenderSvgSelfTest
+
+          - id: SonarMark-OTS-SysML2Tools
+            title: SysML2Tools shall validate the SysML2 model and render its declared views to SVG diagrams.
+            justification: |
+              Composite requirement covering lint and render behaviors. This is a non-requirement
+              grouping node; verification evidence is carried by the atomic child requirements,
+              each of which covers one behavior (lint and render).
+            tags: [ots]
+            children:
+              - SonarMark-OTS-SysML2Tools-Lint
+              - SonarMark-OTS-SysML2Tools-Render

--- a/docs/reqstream/sonar-mark/cli/cli.yaml
+++ b/docs/reqstream/sonar-mark/cli/cli.yaml
@@ -66,26 +66,23 @@ sections:
           - id: SonarMark-Cli-Output
             title: The CLI subsystem shall write normal output to stdout, error output to stderr, support silent suppression of console output, persist all output to a log file when requested, and report a non-zero exit code when errors occur.
             justification: |
-              CI/CD pipelines depend on structured output (stdout/stderr separation), silent mode
-              suppression, log file persistence independent of silent mode, and a meaningful process
-              exit code to drive automated build decisions. Grouping these output-contract behaviors
-              in a dedicated subsystem requirement makes the CLI output guarantee explicit and
-              directs reviewers to the Context unit that implements it.
+              Composite requirement covering the CLI subsystem's output contract: console
+              stream separation with silent suppression, log-file persistence, and exit-code
+              reporting. This is a non-requirement grouping node; verification evidence is
+              carried by the atomic child requirements, each of which covers one observable
+              output behavior.
             children:
               - SonarMark-Cli-Context-ConsoleOutput
               - SonarMark-Cli-Context-LogFile
               - SonarMark-Cli-Context-ExitCode
-            tests:
-              - Cli_SilentMode_WithSilentFlag_SuppressesOutput
-              - Cli_EnforceMode_WithEnforceFlag_SetsEnforceFlag
 
-          - id: SonarMark-Cli-Testability
-            title: The CLI subsystem shall support injection of a mock HTTP client factory to enable test isolation without real network calls.
+          - id: SonarMark-Cli-HttpTransport
+            title: The CLI subsystem shall use an externally supplied HTTP client for SonarQube/SonarCloud communication when one is provided, instead of always constructing one internally.
             justification: |
-              Deterministic automated testing of the full CLI dispatch path requires that network
-              calls to SonarQube/SonarCloud can be replaced with a mock. Accepting a factory
-              delegate through Context.Create allows tests to inject a controlled SonarQubeClient
-              and verify behavior at the subsystem boundary without a live server.
+              Decoupling the CLI subsystem's analysis execution from a concrete network
+              transport allows the enforce-mode exit-code decision to be driven by any HTTP
+              client the caller supplies, including a controlled SonarQubeClient response,
+              without requiring a live server.
             children:
               - SonarMark-Cli-Context-HttpFactory
             tests:

--- a/docs/reqstream/sonar-mark/cli/context.yaml
+++ b/docs/reqstream/sonar-mark/cli/context.yaml
@@ -175,34 +175,91 @@ sections:
                   - Context_Create_NoArguments_ReturnsDefaultContext
                   - Context_WriteError_NormalMode_WritesToConsole
 
+              - id: SonarMark-Cli-Context-ConsoleOutput-Stdout
+                title: The Context unit shall write normal output to stdout when Silent is false.
+                justification: |
+                  Normal (non-error) output must reach stdout so callers and CI systems can capture
+                  informational messages produced during a run.
+                tests:
+                  - Context_WriteLine_NormalMode_WritesToConsole
+
+              - id: SonarMark-Cli-Context-ConsoleOutput-StderrRed
+                title: The Context unit shall write error output to stderr in red when Silent is false.
+                justification: |
+                  Routing error output to stderr keeps it separable from normal output for callers
+                  that redirect the two streams independently, and rendering it in red makes errors
+                  visually distinct when the console is not redirected.
+                tests:
+                  - Context_WriteError_NormalMode_WritesToConsole
+
+              - id: SonarMark-Cli-Context-ConsoleOutput-Silent
+                title: The Context unit shall suppress both normal and error console output when Silent is true.
+                justification: |
+                  Silent mode must suppress all console output, not just normal output, so that
+                  automated environments can rely on the console being completely quiet regardless of
+                  which output method is used.
+                tests:
+                  - Context_WriteLine_SilentMode_DoesNotWriteToConsole
+                  - Context_WriteError_SilentMode_DoesNotWriteToConsole
+
               - id: SonarMark-Cli-Context-ConsoleOutput
                 title: The Context unit shall write normal output to stdout and error output to stderr in red; both shall be suppressed from the console when Silent is true.
                 justification: |
-                  Separating output streams and supporting silent mode allows callers to capture only
-                  error output and suppress all noise in CI/CD environments. Writing error output in
-                  red makes it visually distinct when the console is not redirected.
+                  Composite requirement covering stdout writing, stderr coloring, and silent-mode
+                  suppression. This is a non-requirement grouping node; verification evidence is
+                  carried by the atomic child requirements, each of which covers one observable
+                  behavior.
+                children:
+                  - SonarMark-Cli-Context-ConsoleOutput-Stdout
+                  - SonarMark-Cli-Context-ConsoleOutput-StderrRed
+                  - SonarMark-Cli-Context-ConsoleOutput-Silent
+
+              - id: SonarMark-Cli-Context-LogFile-Open
+                title: The Context unit shall open a log file at creation when --log is specified.
+                justification: |
+                  Opening the log file eagerly at creation, rather than lazily on first write,
+                  ensures that a misconfigured log path is reported immediately as a startup error
+                  rather than surfacing later during the run.
                 tests:
-                  - Context_WriteLine_NormalMode_WritesToConsole
-                  - Context_WriteLine_SilentMode_DoesNotWriteToConsole
-                  - Context_WriteError_NormalMode_WritesToConsole
-                  - Context_WriteError_SilentMode_DoesNotWriteToConsole
+                  - Context_Create_WithLogFile_WritesToLogFile
+
+              - id: SonarMark-Cli-Context-LogFile-WriteRegardlessSilent
+                title: The Context unit shall write all WriteLine and WriteError output to the log file regardless of Silent mode.
+                justification: |
+                  Log files provide a persistent diagnostic record independent of console verbosity
+                  settings, so full diagnostic information must always be captured in the log even
+                  when console output is suppressed.
+                tests:
+                  - Context_Create_WithLogFile_WritesToLogFile
+
+              - id: SonarMark-Cli-Context-LogFile-CloseOnDispose
+                title: The Context unit shall close the log file when Dispose is called.
+                justification: |
+                  Closing the log file on Dispose flushes buffered writes and releases the file
+                  handle so the log file is fully readable and not left locked once the Context is
+                  no longer in use.
+                tests:
+                  - Context_Create_WithLogFile_WritesToLogFile
 
               - id: SonarMark-Cli-Context-LogFile
                 title: The Context unit shall open a log file at creation when --log is specified, write all WriteLine and WriteError output to it regardless of Silent mode, and close it on Dispose.
                 justification: |
-                  Log files provide a persistent diagnostic record independent of console verbosity
-                  settings. Writing all output to the log regardless of Silent mode ensures that
-                  full diagnostic information is always captured even when console output is suppressed.
-                tests:
-                  - Context_Create_WithLogFile_WritesToLogFile
+                  Composite requirement covering log-file open, unconditional write, and disposal
+                  behaviors. This is a non-requirement grouping node; verification evidence is
+                  carried by the atomic child requirements, each of which covers one observable
+                  behavior.
+                children:
+                  - SonarMark-Cli-Context-LogFile-Open
+                  - SonarMark-Cli-Context-LogFile-WriteRegardlessSilent
+                  - SonarMark-Cli-Context-LogFile-CloseOnDispose
 
               - id: SonarMark-Cli-Context-HttpFactory
-                title: The Context unit shall accept and expose an optional HTTP client factory for injecting test doubles.
+                title: The Context unit shall accept and expose an optional HTTP client factory so that callers can supply the HTTP client used for SonarQube/SonarCloud communication instead of it always being constructed internally.
                 justification: |
-                  Test isolation requires that the Context unit can carry a factory delegate that
-                  Program.ProcessSonarAnalysis uses in place of constructing a real SonarQubeClient.
-                  Storing the factory on Context keeps it co-located with all other configuration
-                  state parsed from the command line, and the internal visibility of the property
-                  ensures production code cannot inject a mock accidentally.
+                  Allowing the HTTP client to be supplied externally decouples analysis execution
+                  from a concrete network transport, keeping the factory co-located with all other
+                  configuration state parsed from the command line. The internal visibility of the
+                  property ensures production code cannot substitute a non-standard client
+                  accidentally.
                 tests:
                   - Context_Create_WithHttpClientFactory_ExposesFactory

--- a/docs/sysml2/model/ots.sysml
+++ b/docs/sysml2/model/ots.sysml
@@ -1,0 +1,11 @@
+package OtsDependencies {
+    doc /* Off-the-shelf (OTS) dependencies used by SonarMark. */
+
+    part def TestResults {
+        doc /* OTS: DemaConsulting.TestResults. */
+
+        comment designRef /* Design: docs/design/ots/test-results.md */
+        comment verificationRef /* Verification: docs/verification/ots/test-results.md */
+        comment reqRef /* Requirements: docs/reqstream/ots/test-results.yaml */
+    }
+}

--- a/docs/sysml2/model/shared.sysml
+++ b/docs/sysml2/model/shared.sysml
@@ -1,0 +1,11 @@
+package SharedDependencies {
+    doc /* Shared Packages consumed by SonarMark. */
+
+    part def SonarMarkSharedPackage {
+        doc /* Shared Package: an earlier SonarMark release consumed as a CI dependency of this repository's own build pipeline for self-validation and quality-report generation. */
+
+        comment designRef /* Design: docs/design/shared/sonar-mark.md */
+        comment verificationRef /* Verification: docs/verification/shared/sonar-mark.md */
+        comment reqRef /* Requirements: docs/reqstream/shared/sonar-mark.yaml */
+    }
+}

--- a/docs/sysml2/model/sonar-mark.sysml
+++ b/docs/sysml2/model/sonar-mark.sysml
@@ -1,0 +1,29 @@
+package SonarMark {
+    import OtsDependencies::*;
+    import SharedDependencies::*;
+
+    doc
+    /*
+     * SonarMark is a .NET command-line tool that generates comprehensive markdown reports
+     * from SonarQube/SonarCloud analysis results.
+     */
+
+    part def SonarMarkSystem {
+        doc /* The SonarMark system as a whole. */
+
+        comment testRef /* Test: test/DemaConsulting.SonarMark.Tests/IntegrationTests.cs */
+        comment designRef /* Design: docs/design/sonar-mark.md */
+        comment verificationRef /* Verification: docs/verification/sonar-mark.md */
+        comment reqRef /* Requirements: docs/reqstream/sonar-mark/sonar-mark.yaml */
+
+        part program : Program;
+        part cli : CliSubsystem;
+        part sonarIntegration : SonarIntegrationSubsystem;
+        part reportGeneration : ReportGenerationSubsystem;
+        part selfTest : SelfTestSubsystem;
+
+        part testResults : TestResults;
+
+        part sonarMarkSharedPackage : SonarMarkSharedPackage;
+    }
+}

--- a/docs/sysml2/model/sonar-mark/cli.sysml
+++ b/docs/sysml2/model/sonar-mark/cli.sysml
@@ -1,0 +1,12 @@
+package SonarMark {
+    part def CliSubsystem {
+        doc /* Command-line argument parsing and program-output routing. */
+
+        comment testRef /* Test: test/DemaConsulting.SonarMark.Tests/Cli/CliTests.cs */
+        comment designRef /* Design: docs/design/sonar-mark/cli.md */
+        comment verificationRef /* Verification: docs/verification/sonar-mark/cli.md */
+        comment reqRef /* Requirements: docs/reqstream/sonar-mark/cli/cli.yaml */
+
+        part context : Context;
+    }
+}

--- a/docs/sysml2/model/sonar-mark/cli/context.sysml
+++ b/docs/sysml2/model/sonar-mark/cli/context.sysml
@@ -1,0 +1,11 @@
+package SonarMark {
+    part def Context {
+        doc /* Command-line argument parser and I/O owner for SonarMark. */
+
+        comment sourceRef /* Source: src/DemaConsulting.SonarMark/Cli/Context.cs */
+        comment testRef /* Test: test/DemaConsulting.SonarMark.Tests/Cli/ContextTests.cs */
+        comment designRef /* Design: docs/design/sonar-mark/cli/context.md */
+        comment verificationRef /* Verification: docs/verification/sonar-mark/cli/context.md */
+        comment reqRef /* Requirements: docs/reqstream/sonar-mark/cli/context.yaml */
+    }
+}

--- a/docs/sysml2/model/sonar-mark/program.sysml
+++ b/docs/sysml2/model/sonar-mark/program.sysml
@@ -1,0 +1,11 @@
+package SonarMark {
+    part def Program {
+        doc /* Entry point and execution orchestrator. */
+
+        comment sourceRef /* Source: src/DemaConsulting.SonarMark/Program.cs */
+        comment testRef /* Test: test/DemaConsulting.SonarMark.Tests/ProgramTests.cs */
+        comment designRef /* Design: docs/design/sonar-mark/program.md */
+        comment verificationRef /* Verification: docs/verification/sonar-mark/program.md */
+        comment reqRef /* Requirements: docs/reqstream/sonar-mark/program.yaml */
+    }
+}

--- a/docs/sysml2/model/sonar-mark/report-generation.sysml
+++ b/docs/sysml2/model/sonar-mark/report-generation.sysml
@@ -1,0 +1,12 @@
+package SonarMark {
+    part def ReportGenerationSubsystem {
+        doc /* Aggregates SonarQube data into a structured markdown quality report. */
+
+        comment testRef /* Test: test/DemaConsulting.SonarMark.Tests/ReportGeneration/ReportGenerationTests.cs */
+        comment designRef /* Design: docs/design/sonar-mark/report-generation.md */
+        comment verificationRef /* Verification: docs/verification/sonar-mark/report-generation.md */
+        comment reqRef /* Requirements: docs/reqstream/sonar-mark/report-generation/report-generation.yaml */
+
+        part sonarQualityResult : SonarQualityResult;
+    }
+}

--- a/docs/sysml2/model/sonar-mark/report-generation/sonar-quality-result.sysml
+++ b/docs/sysml2/model/sonar-mark/report-generation/sonar-quality-result.sysml
@@ -1,0 +1,11 @@
+package SonarMark {
+    part def SonarQualityResult {
+        doc /* Aggregates quality gate, issues, and hot-spots data and renders the markdown report. */
+
+        comment sourceRef /* Source: src/DemaConsulting.SonarMark/ReportGeneration/SonarQualityResult.cs */
+        comment testRef /* Test: test/DemaConsulting.SonarMark.Tests/ReportGeneration/SonarQualityResultTests.cs */
+        comment designRef /* Design: docs/design/sonar-mark/report-generation/sonar-quality-result.md */
+        comment verificationRef /* Verification: docs/verification/sonar-mark/report-generation/sonar-quality-result.md */
+        comment reqRef /* Requirements: docs/reqstream/sonar-mark/report-generation/sonar-quality-result.yaml */
+    }
+}

--- a/docs/sysml2/model/sonar-mark/self-test.sysml
+++ b/docs/sysml2/model/sonar-mark/self-test.sysml
@@ -1,0 +1,12 @@
+package SonarMark {
+    part def SelfTestSubsystem {
+        doc /* Self-validation test runner exercised at startup for OTS/BuildMark self-check evidence. */
+
+        comment testRef /* Test: test/DemaConsulting.SonarMark.Tests/SelfTest/SelfTestTests.cs */
+        comment designRef /* Design: docs/design/sonar-mark/self-test.md */
+        comment verificationRef /* Verification: docs/verification/sonar-mark/self-test.md */
+        comment reqRef /* Requirements: docs/reqstream/sonar-mark/self-test/self-test.yaml */
+
+        part validation : Validation;
+    }
+}

--- a/docs/sysml2/model/sonar-mark/self-test/validation.sysml
+++ b/docs/sysml2/model/sonar-mark/self-test/validation.sysml
@@ -1,0 +1,11 @@
+package SonarMark {
+    part def Validation {
+        doc /* Self-validation runner that writes TRX and JUnit result files. */
+
+        comment sourceRef /* Source: src/DemaConsulting.SonarMark/SelfTest/Validation.cs */
+        comment testRef /* Test: test/DemaConsulting.SonarMark.Tests/SelfTest/ValidationTests.cs */
+        comment designRef /* Design: docs/design/sonar-mark/self-test/validation.md */
+        comment verificationRef /* Verification: docs/verification/sonar-mark/self-test/validation.md */
+        comment reqRef /* Requirements: docs/reqstream/sonar-mark/self-test/validation.yaml */
+    }
+}

--- a/docs/sysml2/model/sonar-mark/sonar-integration.sysml
+++ b/docs/sysml2/model/sonar-mark/sonar-integration.sysml
@@ -1,0 +1,14 @@
+package SonarMark {
+    part def SonarIntegrationSubsystem {
+        doc /* SonarQube/SonarCloud REST API integration and data-model definitions. */
+
+        comment testRef /* Test: test/DemaConsulting.SonarMark.Tests/SonarIntegration/SonarIntegrationTests.cs */
+        comment designRef /* Design: docs/design/sonar-mark/sonar-integration.md */
+        comment verificationRef /* Verification: docs/verification/sonar-mark/sonar-integration.md */
+        comment reqRef /* Requirements: docs/reqstream/sonar-mark/sonar-integration/sonar-integration.yaml */
+
+        part sonarQubeClient : SonarQubeClient;
+        part sonarHotSpot : SonarHotSpot;
+        part sonarIssue : SonarIssue;
+    }
+}

--- a/docs/sysml2/model/sonar-mark/sonar-integration/sonar-hot-spot.sysml
+++ b/docs/sysml2/model/sonar-mark/sonar-integration/sonar-hot-spot.sysml
@@ -1,0 +1,11 @@
+package SonarMark {
+    part def SonarHotSpot {
+        doc /* Data record representing a SonarQube security hot-spot. */
+
+        comment sourceRef /* Source: src/DemaConsulting.SonarMark/SonarIntegration/SonarHotSpot.cs */
+        comment testRef /* Test: test/DemaConsulting.SonarMark.Tests/SonarIntegration/SonarHotSpotTests.cs */
+        comment designRef /* Design: docs/design/sonar-mark/sonar-integration/sonar-hot-spot.md */
+        comment verificationRef /* Verification: docs/verification/sonar-mark/sonar-integration/sonar-hot-spot.md */
+        comment reqRef /* Requirements: docs/reqstream/sonar-mark/sonar-integration/sonar-hot-spot.yaml */
+    }
+}

--- a/docs/sysml2/model/sonar-mark/sonar-integration/sonar-issue.sysml
+++ b/docs/sysml2/model/sonar-mark/sonar-integration/sonar-issue.sysml
@@ -1,0 +1,11 @@
+package SonarMark {
+    part def SonarIssue {
+        doc /* Data record representing a SonarQube issue. */
+
+        comment sourceRef /* Source: src/DemaConsulting.SonarMark/SonarIntegration/SonarIssue.cs */
+        comment testRef /* Test: test/DemaConsulting.SonarMark.Tests/SonarIntegration/SonarIssueTests.cs */
+        comment designRef /* Design: docs/design/sonar-mark/sonar-integration/sonar-issue.md */
+        comment verificationRef /* Verification: docs/verification/sonar-mark/sonar-integration/sonar-issue.md */
+        comment reqRef /* Requirements: docs/reqstream/sonar-mark/sonar-integration/sonar-issue.yaml */
+    }
+}

--- a/docs/sysml2/model/sonar-mark/sonar-integration/sonar-qube-client.sysml
+++ b/docs/sysml2/model/sonar-mark/sonar-integration/sonar-qube-client.sysml
@@ -1,0 +1,11 @@
+package SonarMark {
+    part def SonarQubeClient {
+        doc /* HTTP API client that fetches quality gate, issues, and hot-spot data from SonarQube/SonarCloud. */
+
+        comment sourceRef /* Source: src/DemaConsulting.SonarMark/SonarIntegration/SonarQubeClient.cs */
+        comment testRef /* Test: test/DemaConsulting.SonarMark.Tests/SonarIntegration/SonarQubeClientTests.cs */
+        comment designRef /* Design: docs/design/sonar-mark/sonar-integration/sonar-qube-client.md */
+        comment verificationRef /* Verification: docs/verification/sonar-mark/sonar-integration/sonar-qube-client.md */
+        comment reqRef /* Requirements: docs/reqstream/sonar-mark/sonar-integration/sonar-qube-client.yaml */
+    }
+}

--- a/docs/sysml2/views/design-views.sysml
+++ b/docs/sysml2/views/design-views.sysml
@@ -1,0 +1,30 @@
+// Views rendered into docs/design/generated/ for the Design document.
+// Reopens the SonarMark package so each 'expose' statement can reference
+// its target part def directly. Per SysML2Tools syntax, 'expose' is only valid
+// inside a named 'view' usage (not a 'view def' definition), and it - not
+// 'render' - is what scopes the rendered diagram content.
+package SonarMark {
+    view SoftwareStructureView {
+        expose SonarMark;
+    }
+
+    view SonarMarkView {
+        expose SonarMarkSystem;
+    }
+
+    view CliView {
+        expose CliSubsystem;
+    }
+
+    view SonarIntegrationView {
+        expose SonarIntegrationSubsystem;
+    }
+
+    view ReportGenerationView {
+        expose ReportGenerationSubsystem;
+    }
+
+    view SelfTestView {
+        expose SelfTestSubsystem;
+    }
+}

--- a/docs/verification/definition.yaml
+++ b/docs/verification/definition.yaml
@@ -27,6 +27,7 @@ input-files:
   - docs/verification/sonar-mark/self-test/validation.md
   - docs/verification/ots.md
   - docs/verification/ots/test-results.md
+  - docs/verification/ots/sysml2tools.md
   - docs/verification/shared.md
   - docs/verification/shared/sonar-mark.md
 template: template.html

--- a/docs/verification/introduction.md
+++ b/docs/verification/introduction.md
@@ -15,6 +15,15 @@ Local items covered by this document:
 - **SonarMark**: system, subsystem, and unit verification including the Program entry point, Cli subsystem,
   SonarIntegration subsystem, ReportGeneration subsystem, and SelfTest subsystem.
 
+OTS items covered by this document:
+
+- **DemaConsulting.TestResults**: integration verification.
+- **SysML2Tools**: integration verification.
+
+Shared Packages covered by this document:
+
+- **SonarMark (released)**: integration and usage verification.
+
 Out of scope: test infrastructure, build pipeline scripts, and the test project itself
 (`test/DemaConsulting.SonarMark.Tests/`).
 
@@ -30,6 +39,18 @@ Local items have parallel artifacts in:
   `docs/verification/sonar-mark[/{subsystem-name}...]/{item}.md`
 - Source: `src/DemaConsulting.SonarMark[/{SubsystemName}...]/{Item}.cs`
 - Tests: `test/DemaConsulting.SonarMark.Tests[/{SubsystemName}...]/{Item}Tests.cs`
+
+OTS items have integration/usage verification documentation parallel to system folders:
+
+- Requirements: `docs/reqstream/ots/{ots-name}.yaml`
+- Design: `docs/design/ots/{ots-name}.md`
+- Verification: `docs/verification/ots/{ots-name}.md`
+
+Shared Packages have integration/usage verification documentation parallel to system and OTS folders:
+
+- Requirements: `docs/reqstream/shared/{package-name}.yaml`
+- Design: `docs/design/shared/{package-name}.md`
+- Verification: `docs/verification/shared/{package-name}.md`
 
 Review-sets: defined in `.reviewmark.yaml`
 

--- a/docs/verification/ots/sysml2tools.md
+++ b/docs/verification/ots/sysml2tools.md
@@ -1,0 +1,53 @@
+## SysML2Tools Verification
+
+This document provides the verification evidence for the `SysML2Tools` OTS software item.
+Requirements for this OTS item are defined in the SysML2Tools OTS Software Requirements document.
+
+### Required Functionality
+
+DemaConsulting.SysML2Tools validates the SysML2 architecture model under `docs/sysml2/` for syntax
+and reference errors, and renders each view declared in `docs/sysml2/views/design-views.sysml` to
+an SVG diagram embedded in the design documentation. Both behaviors run in the same CI pipeline
+that produces the compiled Design document, so a successful pipeline run is evidence that
+SysML2Tools executed without error.
+
+### Verification Approach
+
+SysML2Tools is verified by a combination of authored self-validation evidence and CI pipeline
+evidence:
+
+- **Self-validation evidence**: `dotnet sysml2tools --validate --results <trx-file>` runs the
+  tool's built-in self-test suite, which exercises `lint` and `render --format svg` against known
+  model fixtures and writes a TRX file consumed by `reqstream --enforce`
+  (`SysML2Tools_LintSelfTest`, `SysML2Tools_RenderSvgSelfTest`).
+- **Pipeline evidence**: `lint.ps1` runs `dotnet sysml2tools lint 'docs/sysml2/**/*.sysml'` against
+  the actual SonarMark model and fails the build on any syntax or reference error. The build-docs
+  job runs `dotnet sysml2tools render` to produce one SVG file per declared view under
+  `docs/design/generated/`. Pandoc then compiles `docs/design/*.md`, which embed those SVG files by
+  filename; if a declared view failed to render, the missing image reference would cause a broken
+  image in the compiled Design HTML and PDF. WeasyPrint renders the result to PDF and FileAssert
+  asserts its content. A CI build failure at either step is evidence that SysML2Tools did not
+  produce the required model validation or diagrams against the real model.
+
+### Test Scenarios
+
+#### SysML2Tools_LintSelfTest
+
+**Scenario**: SysML2Tools is invoked with `--validate`, which exercises `lint` against a known-good
+and a known-bad model fixture as part of its built-in self-test suite.
+
+**Expected**: Exits 0 with no reported syntax or reference errors for the valid fixture, and
+correctly reports an error for the invalid fixture.
+
+#### SysML2Tools_RenderSvgSelfTest
+
+**Scenario**: SysML2Tools is invoked with `--validate`, which exercises `render --format svg`
+against a known-good model fixture as part of its built-in self-test suite.
+
+**Expected**: Exits 0 and produces a non-empty SVG file for the fixture's declared view.
+
+### Acceptance Criteria
+
+N/A - Acceptance criteria are managed at the system integration level. This OTS item is considered
+verified when the integration test scenarios that exercise its functionality pass in the CI
+pipeline.

--- a/docs/verification/sonar-mark/cli.md
+++ b/docs/verification/sonar-mark/cli.md
@@ -3,10 +3,14 @@
 ### Verification Approach
 
 The Cli subsystem is verified by subsystem integration tests in
-`test/DemaConsulting.SonarMark.Tests/Cli/CliTests.cs`. These tests exercise the full dispatch path from
-`Context.Create` through `Program.Run`, using a mock `HttpClientFactory` to avoid network calls.
-Each test confirms that a specific combination of CLI flags results in the correct dispatch, output,
-and exit code, verifying that `Context` and `Program` work together correctly as a subsystem.
+`test/DemaConsulting.SonarMark.Tests/Cli/CliTests.cs`. Most tests exercise the full dispatch path from
+`Context.Create` through `Program.Run` directly, without a mock `HttpClientFactory`, since the covered
+scenarios (version, help, silent mode, enforce-flag parsing, and unknown-argument parsing) do not reach
+the network-bound code paths. One test, `Cli_EnforceMode_WithFailingQualityGate_ReturnsNonZeroExitCode`,
+supplies a mocked `HttpClientFactory` returning a failing (`ERROR`) quality gate response to verify that
+`--enforce` drives a non-zero exit code end-to-end through the full dispatch path. Each test confirms
+that a specific combination of CLI flags results in the correct dispatch, output, and exit code,
+verifying that `Context` and `Program` work together correctly as a subsystem.
 
 ### Test Environment
 
@@ -18,25 +22,38 @@ N/A - standard test environment.
 - Version and help dispatch produce the expected output without errors.
 - Silent mode suppresses all console output.
 - Enforce mode sets the enforce flag that drives the exit code.
+- Enforce mode with a failing quality gate produces a non-zero exit code end-to-end.
+- An unrecognized command-line argument throws `ArgumentException` before any dispatch occurs.
 
 ### Test Scenarios
 
 **VersionDispatchOutputsVersionString**: When the CLI receives `--version`, the full dispatch path
 outputs only the version string and exits with code 0, confirming that the `Context.Version` flag
 routes correctly through `Program.Run`.
-This scenario is tested by `Cli_VersionDispatch_OutputsVersionString`.
+This scenario is tested by `Cli_VersionDispatch_WithVersionFlag_OutputsVersionString`.
 
 **HelpDispatchOutputsHelpText**: When the CLI receives `--help`, the full dispatch path outputs the
 usage and options help text and exits with code 0, confirming that the `Context.Help` flag routes
 correctly through `Program.Run`.
-This scenario is tested by `Cli_HelpDispatch_OutputsHelpText`.
+This scenario is tested by `Cli_HelpDispatch_WithHelpFlag_OutputsHelpText`.
 
 **SilentModeSuppressesOutput**: When the CLI receives `--silent`, no content is written to the console
 even when an error condition is detected, confirming that the silent flag is honoured across the entire
 output path.
-This scenario is tested by `Cli_SilentMode_SuppressesOutput`.
+This scenario is tested by `Cli_SilentMode_WithSilentFlag_SuppressesOutput`.
 
 **EnforceModeSetsFlagForDownstreamProcessing**: When the CLI receives `--enforce`, the `Enforce`
 property on `Context` is set to `true`, confirming that the flag is parsed and made available to
 `Program.ProcessSonarAnalysis` for enforcement decisions.
-This scenario is tested by `Cli_EnforceMode_SetsEnforceFlag`.
+This scenario is tested by `Cli_EnforceMode_WithEnforceFlag_SetsEnforceFlag`.
+
+**EnforceModeWithFailingQualityGateReturnsNonZeroExitCode**: When the CLI receives `--enforce` and a
+mocked `HttpClientFactory` returns a failing (`ERROR`) quality gate response, the full dispatch path
+through `Program.Run` returns a non-zero exit code, confirming that enforce mode drives the exit code
+end-to-end using an externally supplied HTTP client.
+This scenario is tested by `Cli_EnforceMode_WithFailingQualityGate_ReturnsNonZeroExitCode`.
+
+**UnknownArgumentThrowsArgumentException**: When the CLI receives an unrecognized flag, `Context.Create`
+throws `ArgumentException` before any dispatch occurs, confirming that argument parsing rejects
+unsupported flags up front rather than allowing them to reach `Program.Run`.
+This scenario is tested by `Cli_ArgumentParsing_WithUnknownFlag_ThrowsArgumentException`.

--- a/docs/verification/sonar-mark/cli/context.md
+++ b/docs/verification/sonar-mark/cli/context.md
@@ -19,6 +19,10 @@ N/A - standard test environment.
   `Silent=false`, `Validate=false`, `Depth=1`, and `ExitCode=0`.
 - Invalid or missing argument values throw `ArgumentException` with a descriptive message.
 - `WriteError` always sets `ExitCode` to 1 regardless of silent mode.
+- The `SONAR_TOKEN` environment variable is used as a fallback for the authentication token when
+  `--token` is not supplied on the command line.
+- An optional HTTP client factory supplied to `Context.Create` is exposed unchanged via
+  `context.HttpClientFactory`.
 
 #### Test Scenarios
 
@@ -59,9 +63,23 @@ This scenario is tested by `Context_Create_MissingReportFilename_ThrowsException
 deprecated `--report-depth` alias is still accepted and maps to the same property.
 This scenario is tested by `Context_Create_ReportDepthAlias_SetsDepthProperty`.
 
+**MissingReportDepthThrowsException**: `--report-depth` without a following value throws
+`ArgumentException` containing the flag name, confirming that the deprecated alias validates its
+required value the same as the canonical `--depth` flag.
+This scenario is tested by `Context_Create_MissingReportDepth_ThrowsException`.
+
+**InvalidReportDepthThrowsException**: `--report-depth` with a non-integer value, zero, a negative
+value, or a value outside 1–6 throws `ArgumentException`, confirming that the deprecated alias enforces
+the same depth validation range as `--depth`.
+This scenario is tested by `Context_Create_InvalidReportDepth_ThrowsException`.
+
 **DepthSetsDepthProperty**: `--depth 3` sets `context.Depth = 3`, confirming that the canonical
 `--depth` flag is parsed correctly.
 This scenario is tested by `Context_Create_Depth_SetsDepthProperty`.
+
+**MissingDepthThrowsException**: `--depth` without a following value throws `ArgumentException`
+containing the flag name, confirming that the canonical flag validates its required value.
+This scenario is tested by `Context_Create_MissingDepth_ThrowsException`.
 
 **InvalidDepthThrowsException**: `--depth` with a non-integer value, zero, or a value outside 1–6
 throws `ArgumentException`, confirming that the depth validation range is enforced for both spellings.
@@ -71,17 +89,40 @@ This scenario is tested by `Context_Create_InvalidDepth_ThrowsException`.
 that the authentication token is parsed and made available to downstream HTTP calls.
 This scenario is tested by `Context_Create_Token_SetsTokenProperty`.
 
+**WithTokenEnvVarReturnsTokenFromEnvironment**: When `--token` is not supplied on the command line but
+the `SONAR_TOKEN` environment variable is set, `context.Token` is populated from the environment
+variable, confirming that the fallback path allows CI/CD systems to inject the token without a
+command-line argument.
+This scenario is tested by `Context_Create_WithTokenEnvVar_ReturnsTokenFromEnvironment`.
+
+**MissingTokenThrowsException**: `--token` without a following value throws `ArgumentException`
+containing the flag name, confirming that the factory method validates the required token value.
+This scenario is tested by `Context_Create_MissingToken_ThrowsException`.
+
 **ServerSetsServerProperty**: `--server https://sonarcloud.io` stores the URL in `context.Server`,
 confirming that the server base URL is parsed and available for `SonarQubeClient` construction.
 This scenario is tested by `Context_Create_Server_SetsServerProperty`.
+
+**MissingServerThrowsException**: `--server` without a following value throws `ArgumentException`
+containing the flag name, confirming that the factory method validates the required server URL value.
+This scenario is tested by `Context_Create_MissingServer_ThrowsException`.
 
 **ProjectKeySetsProjectKeyProperty**: `--project-key my-project` stores the key in
 `context.ProjectKey`, confirming that the project identifier is parsed and available for API calls.
 This scenario is tested by `Context_Create_ProjectKey_SetsProjectKeyProperty`.
 
+**MissingProjectKeyThrowsException**: `--project-key` without a following value throws
+`ArgumentException` containing the flag name, confirming that the factory method validates the
+required project key value.
+This scenario is tested by `Context_Create_MissingProjectKey_ThrowsException`.
+
 **BranchSetsBranchProperty**: `--branch main` stores the branch name in `context.Branch`, confirming
 that branch filtering is parsed and available for API calls.
 This scenario is tested by `Context_Create_Branch_SetsBranchProperty`.
+
+**MissingBranchThrowsException**: `--branch` without a following value throws `ArgumentException`
+containing the flag name, confirming that the factory method validates the required branch value.
+This scenario is tested by `Context_Create_MissingBranch_ThrowsException`.
 
 **UnsupportedArgumentThrowsException**: An unrecognized flag such as `--unsupported` throws
 `ArgumentException` containing the flag name, confirming that unknown flags are rejected early.
@@ -108,6 +149,10 @@ This scenario is tested by `Context_WriteError_SilentMode_DoesNotWriteToConsole`
 messages are mirrored to the log file, confirming that log-file mirroring works regardless of silent mode.
 This scenario is tested by `Context_Create_WithLogFile_WritesToLogFile`.
 
+**MissingLogFilenameThrowsException**: `--log` without a following filename throws `ArgumentException`
+containing the flag name, confirming that the factory method validates the required log filename value.
+This scenario is tested by `Context_Create_MissingLogFilename_ThrowsException`.
+
 **InvalidLogFilePathThrowsException**: `--log` with a path in a non-existent directory throws
 `InvalidOperationException` containing "Failed to open log file", confirming that file-open failures are
 surfaced as a typed exception.
@@ -117,6 +162,22 @@ This scenario is tested by `Context_Create_InvalidLogFilePath_ThrowsException`.
 confirming that the validation results file is parsed and available for the `Validation` subsystem.
 This scenario is tested by `Context_Create_ResultsFile_SetsResultsProperty`.
 
+**MissingResultsFilenameThrowsException**: `--results` without a following filename throws
+`ArgumentException` containing the flag name, confirming that the factory method validates the
+required results filename value.
+This scenario is tested by `Context_Create_MissingResultsFilename_ThrowsException`.
+
 **ResultAliasSetsResultsProperty**: `--result results.trx` (legacy alias) stores the same value in
 `context.ResultsFile`, confirming that the legacy spelling is accepted for backward compatibility.
 This scenario is tested by `Context_Create_ResultAlias_SetsResultsProperty`.
+
+**MissingResultAliasFilenameThrowsException**: `--result` (legacy alias) without a following filename
+throws `ArgumentException` containing the flag name, confirming that the legacy spelling validates its
+required value the same as the canonical `--results` flag.
+This scenario is tested by `Context_Create_MissingResultAliasFilename_ThrowsException`.
+
+**WithHttpClientFactoryExposesFactory**: `Context.Create` called with an optional HTTP client factory
+delegate exposes the same delegate via `context.HttpClientFactory`, confirming that callers can supply
+the HTTP client used for SonarQube/SonarCloud communication instead of it always being constructed
+internally.
+This scenario is tested by `Context_Create_WithHttpClientFactory_ExposesFactory`.

--- a/docs/verification/sonar-mark/report-generation/sonar-quality-result.md
+++ b/docs/verification/sonar-mark/report-generation/sonar-quality-result.md
@@ -47,7 +47,7 @@ This scenario is tested by `SonarQualityResult_ToMarkdown_NoConditions_ExcludesC
 **NullThresholdAndActualExcludesNullValues**: When a `SonarQualityCondition` has `null`
 `ErrorThreshold` and `ActualValue`, those columns are omitted from the rendered row, confirming that
 optional condition fields are handled without null-reference errors or empty column output.
-This scenario is tested by `SonarQualityResult_ToMarkdown_NullThresholdAndActual_ExcludesNullValues`.
+This scenario is tested by `SonarQualityResult_ToMarkdown_NullThresholdAndActual_RendersEmptyCells`.
 
 **DepthLessThan1ThrowsArgumentOutOfRangeException**: `ToMarkdown(0)` throws
 `ArgumentOutOfRangeException`, confirming that the lower boundary is enforced.
@@ -82,13 +82,13 @@ This scenario is tested by `SonarQualityResult_ToMarkdown_WithSingularCounts_Sho
 
 **WithMultipleIssuesIncludesBlankLinesBetweenItems**: When multiple issues are rendered, a blank line
 separates each item in the output, confirming that the inter-item spacing rule is applied correctly.
-This scenario is tested by `SonarQualityResult_ToMarkdown_WithMultipleIssues_IncludesBlankLinesBetweenItems`.
+This scenario is tested by `SonarQualityResult_ToMarkdown_WithMultipleIssues_IncludesLineBreaksBetweenItems`.
 
 **WithMultipleHotSpotsIncludesBlankLinesBetweenItems**: When multiple hot-spots are rendered, a blank
 line separates each item in the output, confirming that the inter-item spacing rule is applied to
 hot-spots as well as issues.
 This scenario is tested by
-`SonarQualityResult_ToMarkdown_WithMultipleHotSpots_IncludesBlankLinesBetweenItems`.
+`SonarQualityResult_ToMarkdown_WithMultipleHotSpots_IncludesLineBreaksBetweenItems`.
 
 **ComponentWithoutProjectKeyPrefixPassesThroughUnchanged**: When a component path does not begin with
 the project key prefix, it is included unchanged in the rendered output, confirming that the prefix

--- a/docs/verification/sonar-mark/self-test.md
+++ b/docs/verification/sonar-mark/self-test.md
@@ -16,17 +16,37 @@ N/A - standard test environment.
 ### Acceptance Criteria
 
 - All tests in `SelfTestTests` pass with zero failures.
+- `Program.Run` in validate mode with a null context throws `ArgumentNullException`.
 - `Program.Run` in validate mode exits with code 0 when all internal self-validation tests pass.
+- The validation header respects `context.Depth` for its heading level.
 - When `--results` specifies a TRX path, the subsystem writes a valid TRX file containing the
   self-validation test suite name.
+- When `--results` specifies an XML path, the subsystem writes a valid JUnit XML file containing
+  the self-validation test suite content.
 
 ### Test Scenarios
+
+**NullContextThrowsArgumentNullException**: `Validation.Run(null)` throws `ArgumentNullException`,
+confirming that the subsystem entry point guards against a missing context before any validation
+work begins.
+This scenario is tested by `SelfTest_RunValidation_NullContext_ThrowsArgumentNullException`.
 
 **AllTestsPass**: `Program.Run` with `--validate --silent` completes with `ExitCode = 0`, confirming
 that all four internal self-validation scenarios pass and the subsystem pipeline integrates correctly.
 This scenario is tested by `SelfTest_RunValidation_AllTestsPass`.
 
+**RespectsContextDepth**: `Validation.Run` prints the validation header using `context.Depth` for the
+heading level, confirming that the subsystem respects the configured report depth when producing its
+header.
+This scenario is tested by `Validation_Run_WithDepth2_OutputsLevel2Header` in
+`test/DemaConsulting.SonarMark.Tests/SelfTest/ValidationTests.cs`.
+
 **ProducesResultsFile**: `Program.Run` with `--validate --silent --results <trx-path>` creates a TRX
 file at the specified path that contains the self-validation suite identifier, confirming that the
 results file write path works end-to-end within the subsystem.
 This scenario is tested by `SelfTest_RunValidation_ProducesResultsFile`.
+
+**ProducesJUnitResultsFile**: `Program.Run` with `--validate --silent --results <xml-path>` creates a
+JUnit XML file at the specified path that contains the self-validation test suite content, confirming
+that the JUnit XML results file write path also works end-to-end within the subsystem.
+This scenario is tested by `SelfTest_RunValidation_WithJUnitResultsPath_ProducesJUnitResultsFile`.

--- a/docs/verification/sonar-mark/self-test/validation.md
+++ b/docs/verification/sonar-mark/self-test/validation.md
@@ -7,7 +7,8 @@
 specific flags, calls `Validation.Run` directly, and asserts on observable outputs: console output via
 `Console.SetOut` redirection, exit code via `context.ExitCode`, and result files written to a temporary
 directory created per test. The `Validation` unit uses its own internal mock HTTP handler, so no network
-calls are made. Temporary directories are cleaned up in `TestCleanup`.
+calls are made. Temporary directories are cleaned up via `Dispose` (the test class implements
+`IDisposable`).
 
 #### Test Environment
 
@@ -37,7 +38,7 @@ This scenario is tested by `Validation_Run_WithSilentContext_CompletesWithZeroEx
 **OutputsValidationHeader**: `Validation.Run` writes a header line containing the DEMA Consulting
 SonarMark identifier to standard output, confirming that the report header is generated at the correct
 heading level by default.
-This scenario is tested by `Validation_Run_OutputsValidationHeader`.
+This scenario is tested by `Validation_Run_DefaultContext_OutputsValidationHeader`.
 
 **WithDepth2OutputsLevel2Header**: `Validation.Run` with `--depth 2` writes a level-2 heading for the
 validation header, confirming that the heading level respects the configured report depth.
@@ -45,7 +46,7 @@ This scenario is tested by `Validation_Run_WithDepth2_OutputsLevel2Header`.
 
 **ReportsFourPassedTests**: The validation output includes a "Total Tests:" line reflecting four passed
 tests, confirming that all four internal validation scenarios are registered and executed.
-This scenario is tested by `Validation_Run_ReportsFourPassedTests`.
+This scenario is tested by `Validation_Run_FourInternalTests_ReportsFourPassedTests`.
 
 **WithTrxResultsFileWritesTrxFile**: `Validation.Run` with `--results <path>.trx` creates a TRX file at
 the specified path, confirming that the TRX serialization path in `WriteResultsFile` is invoked and

--- a/docs/verification/sonar-mark/sonar-integration.md
+++ b/docs/verification/sonar-mark/sonar-integration.md
@@ -23,6 +23,11 @@ N/A - standard test environment.
   `/api/issues/search` response.
 - `GetQualityResultByBranchAsync` returns a `SonarQualityResult` containing all hot-spots from the
   mocked `/api/hotspots/search` response.
+- `GetQualityResultByBranchAsync` throws `ArgumentNullException` when the server URL is null, before
+  any HTTP call is made.
+- `GetQualityResultByBranchAsync` throws `InvalidOperationException` when the server returns a
+  non-2xx HTTP response.
+- `GetQualityResultByBranchAsync` throws `JsonException` when the server returns a malformed JSON body.
 
 ### Test Scenarios
 
@@ -30,17 +35,33 @@ N/A - standard test environment.
 mock HTTP handler returns a `SonarQualityResult` whose quality gate status matches the status value in
 the canned API response, confirming that the full subsystem data path from HTTP response to result object
 is wired correctly.
-This scenario is tested by `SonarIntegration_FetchQualityResult_ReturnsQualityGateStatus`.
+This scenario is tested by `SonarIntegration_FetchQualityResult_MockedOkResponse_ReturnsQualityGateStatus`.
 
 **FetchQualityResultReturnsIssues**: `SonarQubeClient.GetQualityResultByBranchAsync` with a mock HTTP
 handler returns a `SonarQualityResult` containing the issues defined in the canned API response,
 confirming that issue parsing and assembly work correctly within the subsystem.
-This scenario is tested by `SonarIntegration_FetchQualityResult_ReturnsIssues`.
+This scenario is tested by `SonarIntegration_FetchQualityResult_MockedIssueInResponse_ReturnsIssues`.
 
 **FetchQualityResultReturnsHotSpots**: `SonarQubeClient.GetQualityResultByBranchAsync` with a mock HTTP
 handler returns a `SonarQualityResult` containing the hot-spots defined in the canned API response,
 confirming that security hot-spot parsing and assembly work correctly within the subsystem.
-This scenario is tested by `SonarIntegration_FetchQualityResult_ReturnsHotSpots`.
+This scenario is tested by `SonarIntegration_FetchQualityResult_MockedHotSpotInResponse_ReturnsHotSpots`.
+
+**GetQualityResultNullServerUrlThrowsArgumentNullException**: `SonarQubeClient.GetQualityResultByBranchAsync`
+called with a null server URL throws `ArgumentNullException` before any HTTP call is made, confirming
+that input validation happens up front within the subsystem.
+This scenario is tested by `SonarIntegration_GetQualityResult_NullServerUrl_ThrowsArgumentNullException`.
+
+**GetQualityResultHttpServerErrorThrowsInvalidOperationException**: `SonarQubeClient.GetQualityResultByBranchAsync`
+with a mock HTTP handler that returns an HTTP 500 response throws `InvalidOperationException`, confirming
+that non-success HTTP responses are surfaced as subsystem errors rather than being silently ignored.
+This scenario is tested by `SonarIntegration_GetQualityResult_HttpServerError_ThrowsInvalidOperationException`.
+
+**GetQualityResultMalformedJsonBodyThrowsJsonException**: `SonarQubeClient.GetQualityResultByBranchAsync`
+with a mock HTTP handler that returns an HTTP 200 response with a malformed JSON body throws
+`JsonException`, confirming that JSON parsing failures propagate to the caller rather than being
+swallowed.
+This scenario is tested by `SonarIntegration_GetQualityResult_MalformedJsonBody_ThrowsJsonException`.
 
 **ConditionsReturnedInQualityResult**: When the quality gate API response includes a condition entry,
 `SonarQubeClient.GetQualityResultByBranchAsync` returns a `SonarQualityResult` whose `Conditions` list

--- a/lint.ps1
+++ b/lint.ps1
@@ -84,6 +84,11 @@ if (-not $skipDotnetTools) {
 
     dotnet reviewmark --lint
     if ($LASTEXITCODE -ne 0) { $lintError = $true }
+
+    if (Test-Path docs/sysml2) {
+        dotnet sysml2tools lint 'docs/sysml2/**/*.sysml'
+        if ($LASTEXITCODE -ne 0) { $lintError = $true }
+    }
 }
 
 # [PROJECT-SPECIFIC] Add additional dotnet tool checks here.

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -47,3 +47,4 @@ includes:
   - docs/reqstream/ots/weasyprint.yaml
   - docs/reqstream/ots/fileassert.yaml
   - docs/reqstream/ots/test-results.yaml
+  - docs/reqstream/ots/sysml2tools.yaml

--- a/src/DemaConsulting.SonarMark/Cli/Context.cs
+++ b/src/DemaConsulting.SonarMark/Cli/Context.cs
@@ -384,6 +384,32 @@ internal sealed class Context : IDisposable
         }
 
         /// <summary>
+        ///     Recognized flag tokens, used to detect a missing value when the next token on
+        ///     the command line is itself another recognized flag (e.g. <c>--token --server foo</c>).
+        /// </summary>
+        private static readonly HashSet<string> KnownFlags =
+        [
+            "-v",
+            "--version",
+            "-?",
+            "-h",
+            "--help",
+            "--silent",
+            "--validate",
+            "--enforce",
+            "--log",
+            "--report",
+            "--depth",
+            "--report-depth",
+            "--token",
+            "--server",
+            "--project-key",
+            "--branch",
+            "--result",
+            "--results"
+        ];
+
+        /// <summary>
         ///     Gets a required string argument value
         /// </summary>
         /// <param name="arg">Argument name</param>
@@ -393,11 +419,12 @@ internal sealed class Context : IDisposable
         /// <returns>Argument value</returns>
         /// <exception cref="ArgumentException">
         ///     Thrown when no value follows the argument (i.e., <paramref name="index" /> is
-        ///     beyond the end of <paramref name="args" />).
+        ///     beyond the end of <paramref name="args" />), or when the next token is itself a
+        ///     recognized flag rather than a value.
         /// </exception>
         private static string GetRequiredStringArgument(string arg, string[] args, int index, string description)
         {
-            if (index >= args.Length)
+            if (index >= args.Length || KnownFlags.Contains(args[index]))
             {
                 throw new ArgumentException($"{arg} requires {description}", nameof(args));
             }

--- a/test/DemaConsulting.SonarMark.Tests/Cli/CliTests.cs
+++ b/test/DemaConsulting.SonarMark.Tests/Cli/CliTests.cs
@@ -18,7 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Net;
+using System.Text;
 using DemaConsulting.SonarMark.Cli;
+using DemaConsulting.SonarMark.SonarIntegration;
 using Xunit;
 
 namespace DemaConsulting.SonarMark.Tests.Cli;
@@ -91,10 +94,13 @@ public class CliTests
     [Fact]
     public void Cli_SilentMode_WithSilentFlag_SuppressesOutput()
     {
-        // Arrange - capture console output
+        // Arrange - capture console output (stdout and stderr)
         var originalOut = Console.Out;
+        var originalError = Console.Error;
         using var output = new StringWriter();
+        using var errorOutput = new StringWriter();
         Console.SetOut(output);
+        Console.SetError(errorOutput);
 
         try
         {
@@ -102,13 +108,16 @@ public class CliTests
             using var context = Context.Create(["--silent"]);
             Program.Run(context);
 
-            // Assert - silent mode must suppress all standard output
+            // Assert - silent mode must suppress all standard output and all error output
             var outputText = output.ToString();
+            var errorText = errorOutput.ToString();
             Assert.True(string.IsNullOrWhiteSpace(outputText));
+            Assert.True(string.IsNullOrWhiteSpace(errorText));
         }
         finally
         {
             Console.SetOut(originalOut);
+            Console.SetError(originalError);
         }
     }
 
@@ -131,6 +140,27 @@ public class CliTests
     }
 
     /// <summary>
+    ///     Test that --enforce causes a non-zero exit code when the quality gate fails, exercising the
+    ///     documented quality-gate failure path rather than only flag parsing.
+    /// </summary>
+    [Fact]
+    public void Cli_EnforceMode_WithFailingQualityGate_ReturnsNonZeroExitCode()
+    {
+        // Arrange - mock HTTP client factory that returns a failing (ERROR) quality gate status
+        var mockFactory = (string? _) => new SonarQubeClient(CreateMockFailingQualityGateHttpClient(), false);
+        using var context = Context.Create(
+            ["--server", "https://mock.sonarqube.example", "--project-key", "test-project", "--enforce"],
+            mockFactory);
+
+        // Act - run through Program dispatch with the mocked failing quality gate
+        Program.Run(context);
+
+        // Assert - the non-zero exit code proves --enforce affects the exit code when the
+        // quality gate fails, not just that the flag is parsed
+        Assert.Equal(1, context.ExitCode);
+    }
+
+    /// <summary>
     ///     Test that an unrecognized argument throws ArgumentException.
     /// </summary>
     [Fact]
@@ -138,6 +168,78 @@ public class CliTests
     {
         // Act / Assert - unsupported flag must throw ArgumentException before any dispatch occurs
         Assert.Throws<ArgumentException>(() => Context.Create(["--unknown-flag"]));
+    }
+
+    /// <summary>
+    ///     Creates a mock HttpClient that reports a failing quality gate result, for use in
+    ///     enforcement-mode testing.
+    /// </summary>
+    /// <returns>Mock HttpClient for enforcement testing.</returns>
+    private static HttpClient CreateMockFailingQualityGateHttpClient()
+    {
+        return new HttpClient(new FailingQualityGateMockHandler());
+    }
+
+    /// <summary>
+    ///     Mock HTTP handler that returns a failing (ERROR) quality gate status, so that CLI
+    ///     subsystem tests can prove --enforce affects the exit code without a real SonarQube server.
+    /// </summary>
+    private sealed class FailingQualityGateMockHandler : HttpMessageHandler
+    {
+        /// <inheritdoc/>
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var requestUri = request.RequestUri?.ToString() ?? string.Empty;
+
+            if (requestUri.Contains("/api/components/show"))
+            {
+                var json = """{"component": {"key": "test-project", "name": "Test Project"}}""";
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                });
+            }
+
+            if (requestUri.Contains("/api/qualitygates/project_status"))
+            {
+                var json = """{"projectStatus": {"status": "ERROR", "conditions": []}}""";
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                });
+            }
+
+            if (requestUri.Contains("/api/issues/search"))
+            {
+                var json = """{"issues": []}""";
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                });
+            }
+
+            if (requestUri.Contains("/api/hotspots/search"))
+            {
+                var json = """{"hotspots": []}""";
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                });
+            }
+
+            if (requestUri.Contains("/api/metrics/search"))
+            {
+                var json = """{"metrics": []}""";
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
     }
 }
 

--- a/test/DemaConsulting.SonarMark.Tests/Cli/ContextTests.cs
+++ b/test/DemaConsulting.SonarMark.Tests/Cli/ContextTests.cs
@@ -62,25 +62,36 @@ public sealed class ContextTests : IDisposable
     [Fact]
     public void Context_Create_NoArguments_ReturnsDefaultContext()
     {
-        // Arrange - no setup required
+        // Arrange - save and clear SONAR_TOKEN so the default-token assertion is deterministic
+        // regardless of the ambient environment
+        var previous = Environment.GetEnvironmentVariable("SONAR_TOKEN");
+        Environment.SetEnvironmentVariable("SONAR_TOKEN", null);
 
-        // Act
-        using var context = Context.Create([]);
+        try
+        {
+            // Act
+            using var context = Context.Create([]);
 
-        // Assert
-        Assert.False(context.Version);
-        Assert.False(context.Help);
-        Assert.False(context.Silent);
-        Assert.False(context.Validate);
-        Assert.False(context.Enforce);
-        Assert.Null(context.ReportFile);
-        Assert.Equal(1, context.Depth);
-        Assert.Null(context.Token);
-        Assert.Null(context.Server);
-        Assert.Null(context.ProjectKey);
-        Assert.Null(context.Branch);
-        Assert.Null(context.ResultsFile);
-        Assert.Equal(0, context.ExitCode);
+            // Assert
+            Assert.False(context.Version);
+            Assert.False(context.Help);
+            Assert.False(context.Silent);
+            Assert.False(context.Validate);
+            Assert.False(context.Enforce);
+            Assert.Null(context.ReportFile);
+            Assert.Equal(1, context.Depth);
+            Assert.Null(context.Token);
+            Assert.Null(context.Server);
+            Assert.Null(context.ProjectKey);
+            Assert.Null(context.Branch);
+            Assert.Null(context.ResultsFile);
+            Assert.Equal(0, context.ExitCode);
+        }
+        finally
+        {
+            // Restore the previous environment variable value
+            Environment.SetEnvironmentVariable("SONAR_TOKEN", previous);
+        }
     }
 
     /// <summary>
@@ -400,6 +411,47 @@ public sealed class ContextTests : IDisposable
 
         // Assert
         Assert.Contains("--token requires a token argument", ex.Message);
+    }
+
+    /// <summary>
+    ///     Test creating a context where a string-valued flag is immediately followed by another
+    ///     recognized flag instead of a value. The missing value must be detected rather than the
+    ///     following flag being consumed as the value.
+    /// </summary>
+    [Fact]
+    public void Context_Create_TokenFollowedByFlag_ThrowsException()
+    {
+        // Arrange - no setup required
+
+        // Act
+        var ex = Assert.Throws<ArgumentException>(() => Context.Create(["--token", "--server", "foo"]));
+
+        // Assert
+        Assert.Contains("--token requires a token argument", ex.Message);
+    }
+
+    /// <summary>
+    ///     Test creating a context for every string-valued flag immediately followed by another
+    ///     recognized flag instead of a value, proving the general fix rather than a single case.
+    /// </summary>
+    [Theory]
+    [InlineData("--token", "--token requires a token argument")]
+    [InlineData("--server", "--server requires a server URL argument")]
+    [InlineData("--project-key", "--project-key requires a project key argument")]
+    [InlineData("--branch", "--branch requires a branch name argument")]
+    [InlineData("--report", "--report requires a filename argument")]
+    [InlineData("--results", "--results requires a results filename argument")]
+    [InlineData("--result", "--result requires a results filename argument")]
+    [InlineData("--log", "--log requires a filename argument")]
+    public void Context_Create_StringFlagFollowedByFlag_ThrowsException(string flag, string expectedMessage)
+    {
+        // Arrange - no setup required
+
+        // Act
+        var ex = Assert.Throws<ArgumentException>(() => Context.Create([flag, "--silent"]));
+
+        // Assert
+        Assert.Contains(expectedMessage, ex.Message);
     }
 
     /// <summary>

--- a/test/DemaConsulting.SonarMark.Tests/ProgramTests.cs
+++ b/test/DemaConsulting.SonarMark.Tests/ProgramTests.cs
@@ -473,6 +473,10 @@ public class ProgramTests
     }
 
 
+    /// <summary>
+    ///     Creates a mock HttpClient that reports a failing quality gate result, for use in
+    ///     enforcement-mode testing.
+    /// </summary>
     /// <returns>Mock HttpClient for enforcement testing.</returns>
     private static HttpClient CreateMockFailingQualityGateHttpClient()
     {


### PR DESCRIPTION
This pull request introduces support for SysML2-based architecture modeling and querying, and refines the repository’s review and documentation standards to integrate SysML2 as the authoritative source of software structure. It updates review workflows, adds a new skill for querying SysML2 models, and clarifies context file usage and versioning rules in documentation. The most important changes are grouped below.

**SysML2 Model Integration and Tooling**

* Added the `sysml2tools` CLI as a pinned .NET tool in `.config/dotnet-tools.json` for querying and validating SysML2 models.
* Introduced a new skill, `sysml2tools-query`, with a comprehensive guide (`.github/skills/sysml2tools-query/SKILL.md`) for querying the repository's SysML2 model to understand software structure, relationships, and artifact locations.
* Updated `.cspell.yaml` to recognize `sysml`, `sysml2tools`, and `SysML2Tools` as valid words.
* Added a dedicated work group for `docs/sysml2/` model files in the template sync agent.

**Documentation and Standards Updates**

* Updated design documentation standards to require SysML2-rendered diagrams for the Software Structure section and added a reference to the new `sysml2-modeling.md` standard. [[1]](diffhunk://#diff-e852af079b8628d13c5e5efa606838d0968cb9d5d3f46f07675384f8c1d372d8R11-R12) [[2]](diffhunk://#diff-e852af079b8628d13c5e5efa606838d0968cb9d5d3f46f07675384f8c1d372d8L33-R43)
* Clarified that version numbers should not be recorded in design documentation except for stable standards or placeholders, and that version management is handled in SBOMs.

**Review Process and ReviewMark Configuration**

* Expanded the `.reviewmark.yaml` example to include SysML2 model files in the review scope and clarified the use of context files for review orientation.
* Refined review-set definitions and principles to align with SysML2-based decomposition, including new context file conventions and explicit inclusion of SysML2 models in the `Decomposition` review. [[1]](diffhunk://#diff-694760331e857cb3f3050826fff0ce6f40d6aaee81f234bcae699652de8a99d7L99-L115) [[2]](diffhunk://#diff-694760331e857cb3f3050826fff0ce6f40d6aaee81f234bcae699652de8a99d7R149-L136) [[3]](diffhunk://#diff-694760331e857cb3f3050826fff0ce6f40d6aaee81f234bcae699652de8a99d7L146-L152) [[4]](diffhunk://#diff-694760331e857cb3f3050826fff0ce6f40d6aaee81f234bcae699652de8a99d7L161-L174) [[5]](diffhunk://#diff-694760331e857cb3f3050826fff0ce6f40d6aaee81f234bcae699652de8a99d7R198-L188)
* Updated formal review agent instructions to clarify the distinction between context/reference files and files under review, and to ensure context is used appropriately during reviews.

These changes collectively establish SysML2 as the central source for software structure, streamline review workflows, and ensure documentation and review processes are consistent and maintainable.